### PR TITLE
:sparkles: add endAuction in Account

### DIFF
--- a/src/accounts/AccountV1.sol
+++ b/src/accounts/AccountV1.sol
@@ -500,6 +500,13 @@ contract AccountV1 is AccountStorageV1, IAccount {
         _withdraw(assetAddresses, assetIds, assetAmounts, recipient);
     }
 
+    /**
+     * @notice Sets the "inAuction" flag to false when an auction ends.
+     */
+    function endAuction() external onlyLiquidator {
+        inAuction = false;
+    }
+
     /*///////////////////////////////////////////////////////////////
                     ASSET MANAGEMENT LOGIC
     ///////////////////////////////////////////////////////////////*/

--- a/test/fuzz/accounts/AccountV1/EndAuction.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV1/EndAuction.fuzz.t.sol
@@ -5,13 +5,12 @@
 pragma solidity 0.8.19;
 
 import { AccountV1_Fuzz_Test } from "./_AccountV1.fuzz.t.sol";
-import { Constants } from "../../../utils/Constants.sol";
 import { AccountErrors } from "../../../../src/libraries/Errors.sol";
 
 /**
- * @notice Fuzz tests for the function "getLiquidationValue" of contract "AccountV1".
+ * @notice Fuzz tests for the function "endAuction" of contract "AccountV1".
  */
-contract GetLiquidationValue_AccountV1_Fuzz_Test is AccountV1_Fuzz_Test {
+contract endAuction_AccountV1_Fuzz_Test is AccountV1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                             TEST CONTRACTS
     /////////////////////////////////////////////////////////////// */

--- a/test/fuzz/accounts/AccountV1/EndAuction.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV1/EndAuction.fuzz.t.sol
@@ -1,0 +1,51 @@
+/**
+ * Created by Pragma Labs
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+pragma solidity 0.8.19;
+
+import { AccountV1_Fuzz_Test } from "./_AccountV1.fuzz.t.sol";
+import { Constants } from "../../../utils/Constants.sol";
+import { AccountErrors } from "../../../../src/libraries/Errors.sol";
+
+/**
+ * @notice Fuzz tests for the function "getLiquidationValue" of contract "AccountV1".
+ */
+contract GetLiquidationValue_AccountV1_Fuzz_Test is AccountV1_Fuzz_Test {
+    /* ///////////////////////////////////////////////////////////////
+                            TEST CONTRACTS
+    /////////////////////////////////////////////////////////////// */
+
+    /* ///////////////////////////////////////////////////////////////
+                              SETUP
+    /////////////////////////////////////////////////////////////// */
+
+    function setUp() public override {
+        AccountV1_Fuzz_Test.setUp();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function testFuzz_Revert_endAuction(address nonLiquidator) public {
+        vm.assume(nonLiquidator != accountExtension.liquidator());
+
+        vm.startPrank(nonLiquidator);
+        vm.expectRevert(AccountErrors.OnlyLiquidator.selector);
+        accountExtension.endAuction();
+        vm.stopPrank();
+    }
+
+    function testFuzz_Success_endAuction() public {
+        // Set "inAuction" to true;
+        accountExtension.setInAuction();
+        assertEq(accountExtension.inAuction(), true);
+
+        // Calling endAuction() should set "inAuction" to false.
+        vm.prank(accountExtension.liquidator());
+        accountExtension.endAuction();
+
+        assertEq(accountExtension.inAuction(), false);
+    }
+}


### PR DESCRIPTION
Added a function to set `inAuction `to false by the Liquidator at the end of the auction.
Maybe a better name can be found than` endAuction()`