### PR TITLE
fix: 404 link foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -40,4 +40,4 @@ fuzz = { runs = 200, max_test_rejects = 100_000_000}
 [profile.hf]
 fuzz = { runs = 2_000, max_test_rejects = 1_000_000_000}
 
-# See more config options https://github.com/gakonst/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
Hi! I fixed an outdated link in `foundry.toml`:  
  - **Old:** `https://github.com/gakonst/foundry/tree/master/config`  
  - **New:** `https://github.com/foundry-rs/foundry/tree/master/crates/config`  