### PR TITLE
✨ track exposures to underlying assets per index

### DIFF
--- a/src/asset-modules/abstracts/AbstractDerivedAM.sol
+++ b/src/asset-modules/abstracts/AbstractDerivedAM.sol
@@ -29,10 +29,9 @@ abstract contract DerivedAM is AssetModule {
     mapping(address creditor => RiskParameters riskParameters) public riskParams;
     // Map with the last exposures of each asset for each Creditor.
     mapping(address creditor => mapping(bytes32 assetKey => ExposuresPerAsset)) public lastExposuresAsset;
-    // Map with the last amount of exposure of each underlying asset for each asset for each Creditor.
-    mapping(
-        address creditor => mapping(bytes32 assetKey => mapping(bytes32 underlyingAssetKey => uint256 exposure))
-    ) public lastExposureAssetToUnderlyingAsset;
+    // Map with the last amount of exposure of each underlying asset, by index, for each asset for each Creditor.
+    mapping(address creditor => mapping(bytes32 assetKey => mapping(uint256 index => uint256 exposure))) public
+        lastExposureAssetToUnderlyingAsset;
 
     // Struct with the risk parameters of the protocol for a specific Creditor.
     struct RiskParameters {
@@ -82,6 +81,8 @@ abstract contract DerivedAM is AssetModule {
      * @notice Returns the unique identifiers of the underlying assets.
      * @param assetKey The unique identifier of the asset.
      * @return underlyingAssetKeys The unique identifiers of the underlying assets.
+     * @dev The order and length of the returned array must be constant for a given asset,
+     * since exposures to underlying assets are tracked per index (the same underlying asset can occur at multiple indexes).
      */
     function _getUnderlyingAssets(bytes32 assetKey) internal view virtual returns (bytes32[] memory underlyingAssetKeys);
 
@@ -381,11 +382,10 @@ abstract contract DerivedAM is AssetModule {
             for (uint256 i; i < underlyingAssetKeys.length; ++i) {
                 // Calculate the change in exposure to the underlying assets since last interaction.
                 deltaExposureAssetToUnderlyingAsset = int256(exposureAssetToUnderlyingAssets[i])
-                    - int256(uint256(lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKeys[i]]));
+                    - int256(lastExposureAssetToUnderlyingAsset[creditor][assetKey][i]);
 
                 // Update "lastExposureAssetToUnderlyingAsset".
-                lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKeys[i]] =
-                    exposureAssetToUnderlyingAssets[i];
+                lastExposureAssetToUnderlyingAsset[creditor][assetKey][i] = exposureAssetToUnderlyingAssets[i];
 
                 // Get the USD Value of the total exposure of "Asset" for its "Underlying Assets" at index "i".
                 // If the "underlyingAsset" has one or more underlying assets itself, the lower level
@@ -469,11 +469,10 @@ abstract contract DerivedAM is AssetModule {
         for (uint256 i; i < underlyingAssetKeys.length; ++i) {
             // Calculate the change in exposure to the underlying assets since last interaction.
             deltaExposureAssetToUnderlyingAsset = int256(exposureAssetToUnderlyingAssets[i])
-                - int256(uint256(lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKeys[i]]));
+                - int256(lastExposureAssetToUnderlyingAsset[creditor][assetKey][i]);
 
             // Update "lastExposureAssetToUnderlyingAsset".
-            lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKeys[i]] =
-                exposureAssetToUnderlyingAssets[i];
+            lastExposureAssetToUnderlyingAsset[creditor][assetKey][i] = exposureAssetToUnderlyingAssets[i];
 
             // Get the USD Value of the total exposure of "Asset" for for all of its "Underlying Assets".
             // If an "underlyingAsset" has one or more underlying assets itself, the lower level

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
@@ -167,9 +167,8 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         assertEq(usdExposureAsset, underlyingPMState.usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
-        bytes32 underlyingAssetKey = derivedAM.getKeyFromAsset(assetState.underlyingAsset, assetState.underlyingAssetId);
         assertEq(
-            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, underlyingAssetKey),
+            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, 0),
             assetState.exposureAssetToUnderlyingAsset
         );
 
@@ -244,9 +243,8 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         assertEq(usdExposureAsset, underlyingPMState.usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
-        bytes32 underlyingAssetKey = derivedAM.getKeyFromAsset(assetState.underlyingAsset, assetState.underlyingAssetId);
         assertEq(
-            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, underlyingAssetKey),
+            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, 0),
             assetState.exposureAssetToUnderlyingAsset
         );
 
@@ -316,9 +314,8 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         assertEq(usdExposureAsset, underlyingPMState.usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
-        bytes32 underlyingAssetKey = derivedAM.getKeyFromAsset(assetState.underlyingAsset, assetState.underlyingAssetId);
         assertEq(
-            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, underlyingAssetKey),
+            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, 0),
             assetState.exposureAssetToUnderlyingAsset
         );
 
@@ -329,5 +326,60 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
         assertEq(usdExposureProtocolActual, 0);
+    }
+
+    function testFuzz_Success_processDeposit_DuplicateUnderlyingAssets(
+        address creditor,
+        address asset,
+        uint256 assetId,
+        address underlyingAssetA,
+        address underlyingAssetB,
+        uint256 amount0,
+        uint256 amount1,
+        uint256 rewards
+    ) public {
+        // Given: Two distinct underlying assets.
+        vm.assume(underlyingAssetA != underlyingAssetB);
+
+        // And: id's are smaller or equal to type(uint96).max.
+        assetId = bound(assetId, 0, type(uint96).max);
+
+        // And: "exposure" of the underlying assets is strictly smaller than their "maxExposure".
+        amount0 = bound(amount0, 0, type(uint112).max - 1);
+        rewards = bound(rewards, 0, type(uint112).max - 1 - amount0);
+        amount1 = bound(amount1, 0, type(uint112).max - 1);
+
+        // And: The asset has underlying assets [A, B, A] (the reward token equals one of the pool tokens).
+        address[] memory underlyingAssets = new address[](3);
+        underlyingAssets[0] = underlyingAssetA;
+        underlyingAssets[1] = underlyingAssetB;
+        underlyingAssets[2] = underlyingAssetA;
+        uint256[] memory underlyingAssetIds = new uint256[](3);
+        derivedAM.addAsset(asset, assetId, underlyingAssets, underlyingAssetIds);
+
+        uint256[] memory underlyingAssetsAmounts = new uint256[](3);
+        underlyingAssetsAmounts[0] = amount0;
+        underlyingAssetsAmounts[1] = amount1;
+        underlyingAssetsAmounts[2] = rewards;
+        derivedAM.setUnderlyingAssetsAmounts(underlyingAssetsAmounts);
+
+        // And: State is persisted.
+        derivedAM.setUsdExposureProtocol(creditor, type(uint112).max, 0);
+        registry.setAssetModule(underlyingAssetA, address(primaryAM));
+        registry.setAssetModule(underlyingAssetB, address(primaryAM));
+        primaryAM.setExposure(creditor, underlyingAssetA, 0, 0, type(uint112).max);
+        primaryAM.setExposure(creditor, underlyingAssetB, 0, 0, type(uint112).max);
+
+        // When: "_processDeposit" is called.
+        bytes32 assetKey = derivedAM.getKeyFromAsset(asset, assetId);
+        derivedAM.processDeposit(creditor, assetKey, 1);
+
+        // Then: The exposure to the duplicated underlying asset is the sum of both occurrences.
+        (uint112 lastExposureA,,,) = primaryAM.riskParams(creditor, derivedAM.getKeyFromAsset(underlyingAssetA, 0));
+        assertEq(lastExposureA, amount0 + rewards);
+
+        // And: The exposure to the non-duplicated underlying asset is correct.
+        (uint112 lastExposureB,,,) = primaryAM.riskParams(creditor, derivedAM.getKeyFromAsset(underlyingAssetB, 0));
+        assertEq(lastExposureB, amount1);
     }
 }

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
@@ -123,9 +123,8 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         assertEq(usdExposureAsset, underlyingPMState.usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
-        bytes32 underlyingAssetKey = derivedAM.getKeyFromAsset(assetState.underlyingAsset, assetState.underlyingAssetId);
         assertEq(
-            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, underlyingAssetKey),
+            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, 0),
             assetState.exposureAssetToUnderlyingAsset
         );
 
@@ -195,9 +194,8 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         assertEq(usdExposureAsset, underlyingPMState.usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
-        bytes32 underlyingAssetKey = derivedAM.getKeyFromAsset(assetState.underlyingAsset, assetState.underlyingAssetId);
         assertEq(
-            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, underlyingAssetKey),
+            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, 0),
             assetState.exposureAssetToUnderlyingAsset
         );
 
@@ -263,9 +261,8 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         assertEq(usdExposureAsset, underlyingPMState.usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
-        bytes32 underlyingAssetKey = derivedAM.getKeyFromAsset(assetState.underlyingAsset, assetState.underlyingAssetId);
         assertEq(
-            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, underlyingAssetKey),
+            derivedAM.getExposureAssetToUnderlyingAssetsLast(assetState.creditor, assetKey, 0),
             assetState.exposureAssetToUnderlyingAsset
         );
 
@@ -276,5 +273,64 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
         assertEq(usdExposureProtocolActual, 0);
+    }
+
+    function testFuzz_Success_processWithdrawal_DuplicateUnderlyingAssets(
+        address creditor,
+        address asset,
+        uint256 assetId,
+        address underlyingAssetA,
+        address underlyingAssetB,
+        uint256 amount0,
+        uint256 amount1,
+        uint256 rewards
+    ) public {
+        // Given: Two distinct underlying assets.
+        vm.assume(underlyingAssetA != underlyingAssetB);
+
+        // And: id's are smaller or equal to type(uint96).max.
+        assetId = bound(assetId, 0, type(uint96).max);
+
+        // And: "exposure" of the underlying assets is strictly smaller than their "maxExposure".
+        amount0 = bound(amount0, 0, type(uint112).max - 1);
+        rewards = bound(rewards, 0, type(uint112).max - 1 - amount0);
+        amount1 = bound(amount1, 0, type(uint112).max - 1);
+
+        // And: The asset has underlying assets [A, B, A] (the reward token equals one of the pool tokens).
+        address[] memory underlyingAssets = new address[](3);
+        underlyingAssets[0] = underlyingAssetA;
+        underlyingAssets[1] = underlyingAssetB;
+        underlyingAssets[2] = underlyingAssetA;
+        uint256[] memory underlyingAssetIds = new uint256[](3);
+        derivedAM.addAsset(asset, assetId, underlyingAssets, underlyingAssetIds);
+
+        uint256[] memory underlyingAssetsAmounts = new uint256[](3);
+        underlyingAssetsAmounts[0] = amount0;
+        underlyingAssetsAmounts[1] = amount1;
+        underlyingAssetsAmounts[2] = rewards;
+        derivedAM.setUnderlyingAssetsAmounts(underlyingAssetsAmounts);
+
+        // And: State is persisted.
+        derivedAM.setUsdExposureProtocol(creditor, type(uint112).max, 0);
+        registry.setAssetModule(underlyingAssetA, address(primaryAM));
+        registry.setAssetModule(underlyingAssetB, address(primaryAM));
+        primaryAM.setExposure(creditor, underlyingAssetA, 0, 0, type(uint112).max);
+        primaryAM.setExposure(creditor, underlyingAssetB, 0, 0, type(uint112).max);
+
+        // And: A deposit of the asset was processed.
+        bytes32 assetKey = derivedAM.getKeyFromAsset(asset, assetId);
+        derivedAM.processDeposit(creditor, assetKey, 1);
+
+        // When: "_processWithdrawal" is called with all underlying amounts zero (full withdrawal).
+        derivedAM.setUnderlyingAssetsAmounts(new uint256[](3));
+        derivedAM.processWithdrawal(creditor, assetKey, 0);
+
+        // Then: The exposure of the underlying Asset Module to the duplicated underlying asset is zero again.
+        (uint112 lastExposureA,,,) = primaryAM.riskParams(creditor, derivedAM.getKeyFromAsset(underlyingAssetA, 0));
+        assertEq(lastExposureA, 0);
+
+        // And: The exposure to the non-duplicated underlying asset is zero again.
+        (uint112 lastExposureB,,,) = primaryAM.riskParams(creditor, derivedAM.getKeyFromAsset(underlyingAssetB, 0));
+        assertEq(lastExposureB, 0);
     }
 }

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectDeposit.fuzz.t.sol
@@ -235,18 +235,12 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         // And: Exposures to the underlying assets are updated.
         // Token0:
         bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-        assertEq(
-            uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-            amount0
-        );
+        assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
         (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
         assertEq(exposure, amount0 + initialExposure0);
         // Token1:
         underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-        assertEq(
-            uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-            amount1
-        );
+        assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
         (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
         assertEq(exposure, amount1 + initialExposure1);
     }
@@ -311,18 +305,12 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -386,18 +374,12 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -465,18 +447,12 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         // And: Exposures to the underlying assets are updated.
         // Token0:
         bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-        assertEq(
-            uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-            amount0
-        );
+        assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
         (uint128 exposure,,,) = nativeTokenAM.riskParams(address(creditorUsd), underlyingAssetKey);
         assertEq(exposure, amount0 + initialExposure0);
         // Token1:
         underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-        assertEq(
-            uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-            amount1
-        );
+        assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
         (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
         assertEq(exposure, amount1 + initialExposure1);
     }

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectWithdrawal.fuzz.t.sol
@@ -99,18 +99,12 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -169,18 +163,12 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -242,18 +230,12 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
             // And : Exposures are unchanged
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -318,18 +300,12 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = nativeTokenAM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -134,18 +134,12 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -211,18 +205,12 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -284,18 +272,12 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -362,18 +344,12 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = nativeTokenAM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -103,18 +103,12 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -176,18 +170,12 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -248,18 +236,12 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
 
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -325,18 +307,12 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = nativeTokenAM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }

--- a/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectDeposit.fuzz.t.sol
@@ -212,18 +212,12 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -319,18 +313,12 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -434,18 +422,12 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -130,18 +130,12 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -231,18 +225,12 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -337,18 +325,12 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
 

--- a/test/fuzz/asset-modules/SlipstreamAM/processDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/processDirectDeposit.fuzz.t.sol
@@ -387,18 +387,12 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -493,18 +487,12 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -609,18 +597,12 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/SlipstreamAM/processDirectWithdrawal.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/processDirectWithdrawal.t.sol
@@ -132,18 +132,12 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -233,18 +227,12 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -339,18 +327,12 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(slipstreamAM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
 

--- a/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -212,18 +212,12 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -318,16 +312,12 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -429,18 +419,12 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -131,16 +131,12 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -230,16 +226,12 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -334,18 +326,12 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
 

--- a/test/fuzz/asset-modules/UniswapV3AM/processDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/processDirectDeposit.fuzz.t.sol
@@ -389,18 +389,12 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -495,16 +489,12 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -606,18 +596,12 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/UniswapV3AM/processDirectWithdrawalfuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/processDirectWithdrawalfuzz.t.sol
@@ -132,16 +132,12 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -231,16 +227,12 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey), 0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -335,18 +327,12 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
             );
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniV3AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
 

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectDeposit.fuzz.t.sol
@@ -235,18 +235,12 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         // And: Exposures to the underlying assets are updated.
         // Token0:
         bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-        assertEq(
-            uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-            amount0
-        );
+        assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
         (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
         assertEq(exposure, amount0 + initialExposure0);
         // Token1:
         underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-        assertEq(
-            uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-            amount1
-        );
+        assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
         (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
         assertEq(exposure, amount1 + initialExposure1);
     }
@@ -311,18 +305,12 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -386,18 +374,12 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectWithdrawal.fuzz.t.sol
@@ -99,18 +99,12 @@ contract ProcessDirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -169,18 +163,12 @@ contract ProcessDirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -242,18 +230,12 @@ contract ProcessDirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
             // And : Exposures are unchanged
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectDeposit.fuzz.t.sol
@@ -134,18 +134,12 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }
@@ -211,18 +205,12 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -284,18 +272,12 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
             // And: Exposures to the underlying assets are of the old liquidity.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -103,18 +103,12 @@ contract ProcessIndirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -176,18 +170,12 @@ contract ProcessIndirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4
             // And: Exposures to the underlying assets are updated.
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), 0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), 0);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, initialExposure1);
         }
@@ -248,18 +236,12 @@ contract ProcessIndirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4
 
             // Token0:
             bytes32 underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token0)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount0
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 0), amount0);
             (uint128 exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount0 + initialExposure0);
             // Token1:
             underlyingAssetKey = bytes32(abi.encodePacked(uint96(0), address(token1)));
-            assertEq(
-                uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, underlyingAssetKey),
-                amount1
-            );
+            assertEq(uniswapV4AM.getExposureAssetToUnderlyingAssetsLast(address(creditorUsd), assetKey, 1), amount1);
             (exposure,,,) = erc20AM.riskParams(address(creditorUsd), underlyingAssetKey);
             assertEq(exposure, amount1 + initialExposure1);
         }

--- a/test/utils/extensions/DefaultUniswapV4AMExtension.sol
+++ b/test/utils/extensions/DefaultUniswapV4AMExtension.sol
@@ -23,13 +23,12 @@ contract DefaultUniswapV4AMExtension is DefaultUniswapV4AM {
         lastUsdExposureAsset = lastExposuresAsset[creditor][assetKey].lastUsdExposureAsset;
     }
 
-    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, bytes32 underlyingAssetKey)
+    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, uint256 index)
         external
         view
         returns (uint256 exposureAssetToUnderlyingAssetsLast_)
     {
-        exposureAssetToUnderlyingAssetsLast_ =
-            lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKey];
+        exposureAssetToUnderlyingAssetsLast_ = lastExposureAssetToUnderlyingAsset[creditor][assetKey][index];
     }
 
     function getPositionManager() public view returns (address positionManager) {

--- a/test/utils/extensions/DerivedAMExtension.sol
+++ b/test/utils/extensions/DerivedAMExtension.sol
@@ -19,13 +19,12 @@ abstract contract DerivedAMExtension is DerivedAM {
         lastUsdExposureAsset = lastExposuresAsset[creditor][assetKey].lastUsdExposureAsset;
     }
 
-    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, bytes32 underlyingAssetKey)
+    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, uint256 index)
         external
         view
         returns (uint256 exposureAssetToUnderlyingAssetsLast_)
     {
-        exposureAssetToUnderlyingAssetsLast_ =
-            lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKey];
+        exposureAssetToUnderlyingAssetsLast_ = lastExposureAssetToUnderlyingAsset[creditor][assetKey][index];
     }
 
     function setUsdExposureProtocol(address creditor, uint112 maxUsdExposureProtocol_, uint112 usdExposureProtocol_)
@@ -39,17 +38,16 @@ abstract contract DerivedAMExtension is DerivedAM {
         address creditor,
         address asset,
         uint256 assetId,
-        address underLyingAsset,
-        uint256 underlyingAssetId,
+        address,
+        uint256,
         uint112 exposureAssetLast,
         uint112 lastUsdExposureAsset,
         uint128 exposureAssetToUnderlyingAssetLast
     ) public {
         bytes32 assetKey = _getKeyFromAsset(asset, assetId);
-        bytes32 underLyingAssetKey = _getKeyFromAsset(underLyingAsset, underlyingAssetId);
         lastExposuresAsset[creditor][assetKey].lastExposureAsset = exposureAssetLast;
         lastExposuresAsset[creditor][assetKey].lastUsdExposureAsset = lastUsdExposureAsset;
-        lastExposureAssetToUnderlyingAsset[creditor][assetKey][underLyingAssetKey] = exposureAssetToUnderlyingAssetLast;
+        lastExposureAssetToUnderlyingAsset[creditor][assetKey][0] = exposureAssetToUnderlyingAssetLast;
     }
 
     function getRateUnderlyingAssetsToUsd(address creditor, bytes32[] memory underlyingAssetKeys)

--- a/test/utils/extensions/SlipstreamAMExtension.sol
+++ b/test/utils/extensions/SlipstreamAMExtension.sol
@@ -21,13 +21,12 @@ contract SlipstreamAMExtension is SlipstreamAM {
         lastUsdExposureAsset = lastExposuresAsset[creditor][assetKey].lastUsdExposureAsset;
     }
 
-    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, bytes32 underlyingAssetKey)
+    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, uint256 index)
         external
         view
         returns (uint256 exposureAssetToUnderlyingAssetsLast_)
     {
-        exposureAssetToUnderlyingAssetsLast_ =
-            lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKey];
+        exposureAssetToUnderlyingAssetsLast_ = lastExposureAssetToUnderlyingAsset[creditor][assetKey][index];
     }
 
     function getNonFungiblePositionManager() public view returns (address nonFungiblePositionManager) {

--- a/test/utils/extensions/UniswapV3AMExtension.sol
+++ b/test/utils/extensions/UniswapV3AMExtension.sol
@@ -21,13 +21,12 @@ contract UniswapV3AMExtension is UniswapV3AM {
         lastUsdExposureAsset = lastExposuresAsset[creditor][assetKey].lastUsdExposureAsset;
     }
 
-    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, bytes32 underlyingAssetKey)
+    function getExposureAssetToUnderlyingAssetsLast(address creditor, bytes32 assetKey, uint256 index)
         external
         view
         returns (uint256 exposureAssetToUnderlyingAssetsLast_)
     {
-        exposureAssetToUnderlyingAssetsLast_ =
-            lastExposureAssetToUnderlyingAsset[creditor][assetKey][underlyingAssetKey];
+        exposureAssetToUnderlyingAssetsLast_ = lastExposureAssetToUnderlyingAsset[creditor][assetKey][index];
     }
 
     function getNonFungiblePositionManager() public view returns (address nonFungiblePositionManager) {

--- a/test/utils/mocks/asset-modules/DerivedAMMock.sol
+++ b/test/utils/mocks/asset-modules/DerivedAMMock.sol
@@ -11,7 +11,7 @@ contract DerivedAMMock is DerivedAMExtension {
 
     mapping(bytes32 assetKey => bytes32[] underlyingAssetKeys) internal assetToUnderlyingAssets;
 
-    uint256 internal underlyingAssetAmount;
+    uint256[] internal underlyingAssetAmounts;
     bool internal returnRateUnderlyingAssetToUsd;
     uint256 internal rateUnderlyingAssetToUsd;
 
@@ -22,7 +22,13 @@ contract DerivedAMMock is DerivedAMExtension {
     function isAllowed(address asset, uint256) public view override returns (bool) { }
 
     function setUnderlyingAssetsAmount(uint256 underlyingAssetAmount_) public {
-        underlyingAssetAmount = underlyingAssetAmount_;
+        uint256[] memory underlyingAssetAmounts_ = new uint256[](1);
+        underlyingAssetAmounts_[0] = underlyingAssetAmount_;
+        underlyingAssetAmounts = underlyingAssetAmounts_;
+    }
+
+    function setUnderlyingAssetsAmounts(uint256[] memory underlyingAssetAmounts_) public {
+        underlyingAssetAmounts = underlyingAssetAmounts_;
     }
 
     function setRateUnderlyingAssetToUsd(uint256 rateUnderlyingAssetToUsd_) public {
@@ -52,18 +58,19 @@ contract DerivedAMMock is DerivedAMExtension {
         internal
         view
         override
-        returns (uint256[] memory underlyingAssetsAmount, AssetValueAndRiskFactors[] memory rateUnderlyingAssetsToUsd)
+        returns (uint256[] memory underlyingAssetsAmounts_, AssetValueAndRiskFactors[] memory rateUnderlyingAssetsToUsd)
     {
-        underlyingAssetsAmount = new uint256[](1);
-        underlyingAssetsAmount[0] = underlyingAssetAmount;
+        underlyingAssetsAmounts_ = underlyingAssetAmounts;
 
         // If rateUnderlyingAssetToUsd is set, also return rateUnderlyingAssetsToUsd.
         if (returnRateUnderlyingAssetToUsd) {
-            rateUnderlyingAssetsToUsd = new AssetValueAndRiskFactors[](1);
-            rateUnderlyingAssetsToUsd[0].assetValue = rateUnderlyingAssetToUsd;
+            rateUnderlyingAssetsToUsd = new AssetValueAndRiskFactors[](underlyingAssetsAmounts_.length);
+            for (uint256 i; i < underlyingAssetsAmounts_.length; ++i) {
+                rateUnderlyingAssetsToUsd[i].assetValue = rateUnderlyingAssetToUsd;
+            }
         }
 
-        return (underlyingAssetsAmount, rateUnderlyingAssetsToUsd);
+        return (underlyingAssetsAmounts_, rateUnderlyingAssetsToUsd);
     }
 
     function _getUnderlyingAssets(bytes32 assetKey) internal view override returns (bytes32[] memory underlyingAssets) {


### PR DESCRIPTION
`lastExposureAssetToUnderlyingAsset` is keyed by the index in the underlying assets array instead of by the underlying asset key. The same underlying asset can now occur at multiple indexes (e.g. a staked liquidity position where the reward token is one of the pool tokens), with each occurrence synced against its own slot. Requires `_getUnderlyingAssets` to return a stable-ordered array per asset, documented in its NatSpec.

Adds fuzz coverage for repeated underlying assets on deposit and withdrawal, and migrates the test scaffolding to the index-based getter.