### PR TITLE
♻️ Cap reward and fee per-liquidity deltas to uint128

### DIFF
--- a/src/asset-modules/Aerodrome-Finance/WrappedAerodromeAM.sol
+++ b/src/asset-modules/Aerodrome-Finance/WrappedAerodromeAM.sol
@@ -581,11 +581,17 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
             // Calculate the change in FeePerLiquidity.
             uint256 deltaFee0PerLiquidity = fee0.mulDivDown(1e18, poolState_.totalWrapped);
             uint256 deltaFee1PerLiquidity = fee1.mulDivDown(1e18, poolState_.totalWrapped);
+            // Cap the deltas so an overflow can't block valuation and the downcasts can't truncate.
+            // Excess is lost, but a realistic reward accrual never approaches type(uint128).max.
+            if (deltaFee0PerLiquidity > type(uint128).max) deltaFee0PerLiquidity = type(uint128).max;
+            if (deltaFee1PerLiquidity > type(uint128).max) deltaFee1PerLiquidity = type(uint128).max;
             // Calculate and update the new FeePerLiquidity of the Pool.
             // unchecked: FeePerLiquidity can overflow, what matters is the delta in FeePerLiquidity between two interactions.
             unchecked {
-                poolState_.fee0PerLiquidity = poolState_.fee0PerLiquidity + deltaFee0PerLiquidity.safeCastTo128();
-                poolState_.fee1PerLiquidity = poolState_.fee1PerLiquidity + deltaFee1PerLiquidity.safeCastTo128();
+                // forge-lint: disable-next-item(unsafe-typecast)
+                poolState_.fee0PerLiquidity = poolState_.fee0PerLiquidity + uint128(deltaFee0PerLiquidity);
+                // forge-lint: disable-next-item(unsafe-typecast)
+                poolState_.fee1PerLiquidity = poolState_.fee1PerLiquidity + uint128(deltaFee1PerLiquidity);
             }
 
             if (positionState_.amountWrapped > 0) {

--- a/src/asset-modules/abstracts/AbstractStakingAM.sol
+++ b/src/asset-modules/abstracts/AbstractStakingAM.sol
@@ -537,11 +537,15 @@ abstract contract StakingAM is DerivedAM, ERC721, ReentrancyGuard {
             // Fetch the current reward balance from the staking contract and calculate the change in RewardPerToken.
             uint256 deltaRewardPerToken =
                 _getCurrentReward(positionState_.asset).mulDivDown(1e18, assetState_.totalStaked);
+            // Cap the delta so an overflow can't block valuation and the downcast can't truncate.
+            // Excess is lost, but a realistic reward accrual never approaches type(uint128).max.
+            if (deltaRewardPerToken > type(uint128).max) deltaRewardPerToken = type(uint128).max;
             // Calculate and update the new RewardPerToken of the asset.
             // unchecked: RewardPerToken can overflow, what matters is the delta in RewardPerToken between two interactions.
             unchecked {
+                // forge-lint: disable-next-item(unsafe-typecast)
                 assetState_.lastRewardPerTokenGlobal =
-                    assetState_.lastRewardPerTokenGlobal + SafeCastLib.safeCastTo128(deltaRewardPerToken);
+                    assetState_.lastRewardPerTokenGlobal + uint128(deltaRewardPerToken);
             }
 
             // Calculate the new positionState.

--- a/test/fuzz/asset-modules/AbstractStakingAM/GetRewardBalances.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/GetRewardBalances.fuzz.t.sol
@@ -41,42 +41,7 @@ contract GetRewardBalances_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         assetState.totalStaked = uint128(bound(assetState.totalStaked, 1, type(uint128).max));
 
         // And: deltaRewardPerToken mulDivDown overflows.
-        currentRewardGlobal = bound(currentRewardGlobal, type(uint256).max / 1e18, type(uint256).max);
-
-        // And: State is persisted.
-        setStakingAMState(assetState, positionState, asset, positionId);
-        stakingAM.setActualRewardBalance(asset, currentRewardGlobal);
-
-        // When: Calling _getRewardBalances().
-        // Then: transaction reverts in safe cast.
-        StakingAM.AssetState memory assetState_ = StakingAM.AssetState({
-            allowed: true,
-            lastRewardPerTokenGlobal: assetState.lastRewardPerTokenGlobal,
-            totalStaked: assetState.totalStaked
-        });
-        vm.expectRevert(bytes(""));
-        stakingAM.getRewardBalances(assetState_, positionState);
-    }
-
-    function testFuzz_Revert_getRewardBalances_NonZeroTotalStaked_OverflowDeltaRewardPerToken_SafeCast(
-        StakingAMStateForAsset memory assetState,
-        StakingAM.PositionState memory positionState,
-        uint256 currentRewardGlobal,
-        uint96 positionId,
-        uint8 assetDecimals
-    ) public {
-        // Given : Add an asset
-        address asset = addAsset(assetDecimals);
-
-        // more than 1gwei is staked.
-        assetState.totalStaked = uint128(bound(assetState.totalStaked, 1, type(uint128).max - 1));
-
-        // And: deltaRewardPerToken is bigger as type(uint128).max (overflow safeCastTo128).
-        uint256 lowerBound = 1
-            + ((assetState.totalStaked < 1e18)
-                    ? uint256(type(uint128).max).mulDivUp(assetState.totalStaked, 1e18)
-                    : uint256(type(uint128).max) * assetState.totalStaked / 1e18 + assetState.totalStaked);
-        currentRewardGlobal = bound(currentRewardGlobal, lowerBound, type(uint256).max);
+        currentRewardGlobal = bound(currentRewardGlobal, type(uint256).max / 1e18 + 1, type(uint256).max);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);
@@ -200,6 +165,53 @@ contract GetRewardBalances_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         });
         vm.expectRevert(bytes(""));
         stakingAM.getRewardBalances(assetState_, positionState);
+    }
+
+    function testFuzz_Success_getRewardBalances_NonZeroTotalStaked_CapDeltaRewardPerToken(
+        StakingAMStateForAsset memory assetState,
+        StakingAM.PositionState memory positionState,
+        uint256 currentRewardGlobal,
+        uint96 positionId,
+        uint8 assetDecimals
+    ) public {
+        // Given : Add an asset
+        address asset = addAsset(assetDecimals);
+
+        // And: totalStaked is bounded so mulDivDown does not overflow.
+        assetState.totalStaked = uint128(bound(assetState.totalStaked, 1, 1e18));
+
+        // And: deltaRewardPerToken is bigger as type(uint128).max (capped instead of reverting).
+        uint256 lowerBound = uint256(type(uint128).max) * assetState.totalStaked / 1e18 + 1;
+        currentRewardGlobal = bound(currentRewardGlobal, lowerBound, type(uint256).max / 1e18);
+
+        // And: no rewards accrue to the position.
+        positionState.amountStaked = 0;
+
+        // And: State is persisted.
+        setStakingAMState(assetState, positionState, asset, positionId);
+        stakingAM.setActualRewardBalance(asset, currentRewardGlobal);
+
+        // When : Calling _getRewardBalances().
+        StakingAM.AssetState memory assetState_ = StakingAM.AssetState({
+            allowed: true,
+            lastRewardPerTokenGlobal: assetState.lastRewardPerTokenGlobal,
+            totalStaked: assetState.totalStaked
+        });
+        StakingAM.PositionState memory positionState_;
+        (assetState_, positionState_) = stakingAM.getRewardBalances(assetState_, positionState);
+
+        // Then : deltaRewardPerToken is capped at type(uint128).max.
+        uint128 rewardPerToken;
+        unchecked {
+            rewardPerToken = assetState.lastRewardPerTokenGlobal + type(uint128).max;
+        }
+        assertEq(assetState_.lastRewardPerTokenGlobal, rewardPerToken);
+        assertEq(assetState_.totalStaked, assetState.totalStaked);
+
+        assertEq(positionState_.asset, positionState.asset);
+        assertEq(positionState_.amountStaked, 0);
+        assertEq(positionState_.lastRewardPerTokenPosition, rewardPerToken);
+        assertEq(positionState_.lastRewardPosition, positionState.lastRewardPosition);
     }
 
     function testFuzz_Success_getRewardBalances_ZeroTotalStaked(

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/GetFeeBalances.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/GetFeeBalances.fuzz.t.sol
@@ -67,54 +67,6 @@ contract GetFeeBalances_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_
         wrappedAerodromeAM.getFeeBalances(poolState, positionState, fee0, fee1);
     }
 
-    function testFuzz_Revert_getFeeBalances_NonZeroTotalWrapped_OverflowDeltaFee0PerLiquidity_SafeCast(
-        WrappedAerodromeAM.PoolState memory poolState,
-        WrappedAerodromeAM.PositionState memory positionState,
-        uint256 fee0,
-        uint256 fee1
-    ) public {
-        // Given: more than 1 gwei is staked.
-        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, type(uint128).max - 1));
-
-        // And: deltaFee0PerLiquidity is bigger as type(uint128).max (overflow safeCastTo128).
-        uint256 lowerBound = (poolState.totalWrapped < 1e18)
-            ? uint256(type(uint128).max).mulDivUp(poolState.totalWrapped, 1e18)
-            : uint256(type(uint128).max) * poolState.totalWrapped / 1e18 + poolState.totalWrapped;
-        fee0 = bound(fee0, lowerBound + 1, type(uint256).max);
-
-        // And: deltaFee1PerLiquidity does not overflow.
-        fee1 = bound(fee1, 0, type(uint256).max / 1e18);
-
-        // When: Calling _getFeeBalances().
-        // Then: transaction reverts.
-        vm.expectRevert(bytes(""));
-        wrappedAerodromeAM.getFeeBalances(poolState, positionState, fee0, fee1);
-    }
-
-    function testFuzz_Revert_getFeeBalances_NonZeroTotalWrapped_OverflowDeltaFee1PerLiquidity_SafeCast(
-        WrappedAerodromeAM.PoolState memory poolState,
-        WrappedAerodromeAM.PositionState memory positionState,
-        uint256 fee0,
-        uint256 fee1
-    ) public {
-        // Given: more than 1 gwei is staked.
-        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, type(uint128).max - 1));
-
-        // And: deltaFee0PerLiquidity is smaller or equal as type(uint128).max (no overflow safeCastTo128).
-        fee0 = bound(fee0, 0, uint256(type(uint128).max) * poolState.totalWrapped / 1e18);
-
-        // And: deltaFee1PerLiquidity is bigger as type(uint128).max (overflow safeCastTo128).
-        uint256 lowerBound = (poolState.totalWrapped < 1e18)
-            ? uint256(type(uint128).max).mulDivUp(poolState.totalWrapped, 1e18)
-            : uint256(type(uint128).max) * poolState.totalWrapped / 1e18 + poolState.totalWrapped;
-        fee1 = bound(fee1, lowerBound + 1, type(uint256).max);
-
-        // When: Calling _getFeeBalances().
-        // Then: transaction reverts.
-        vm.expectRevert(bytes(""));
-        wrappedAerodromeAM.getFeeBalances(poolState, positionState, fee0, fee1);
-    }
-
     function testFuzz_Revert_getFeeBalances_NonZeroTotalWrapped_OverflowDeltaFee0(
         WrappedAerodromeAM.PoolState memory poolState,
         WrappedAerodromeAM.PositionState memory positionState,
@@ -326,6 +278,88 @@ contract GetFeeBalances_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_
 
         vm.expectRevert(bytes(""));
         wrappedAerodromeAM.getFeeBalances(poolState, positionState, fee0, fee1);
+    }
+
+    function testFuzz_Success_getFeeBalances_NonZeroTotalWrapped_CapDeltaFee0PerLiquidity(
+        WrappedAerodromeAM.PoolState memory poolState,
+        WrappedAerodromeAM.PositionState memory positionState,
+        uint256 fee0,
+        uint256 fee1
+    ) public view {
+        // Given: totalWrapped is bounded so mulDivDown does not overflow.
+        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, 1e18));
+
+        // And: deltaFee0PerLiquidity is bigger as type(uint128).max (capped instead of reverting).
+        fee0 = bound(fee0, uint256(type(uint128).max) * poolState.totalWrapped / 1e18 + 1, type(uint256).max / 1e18);
+
+        // And: deltaFee1PerLiquidity does not overflow.
+        fee1 = bound(fee1, 0, uint256(type(uint128).max) * poolState.totalWrapped / 1e18);
+
+        // And: no fees accrue to the position.
+        positionState.amountWrapped = 0;
+
+        // When : Calling _getFeeBalances().
+        (WrappedAerodromeAM.PoolState memory poolState_, WrappedAerodromeAM.PositionState memory positionState_) =
+            wrappedAerodromeAM.getFeeBalances(poolState, positionState, fee0, fee1);
+
+        // Then : deltaFee0PerLiquidity is capped at type(uint128).max.
+        uint128 fee0PerLiquidity;
+        uint128 fee1PerLiquidity;
+        unchecked {
+            fee0PerLiquidity = poolState.fee0PerLiquidity + type(uint128).max;
+            fee1PerLiquidity = poolState.fee1PerLiquidity + uint128(fee1.mulDivDown(1e18, poolState.totalWrapped));
+        }
+        assertEq(poolState_.fee0PerLiquidity, fee0PerLiquidity);
+        assertEq(poolState_.fee1PerLiquidity, fee1PerLiquidity);
+        assertEq(poolState_.totalWrapped, poolState.totalWrapped);
+
+        assertEq(positionState_.fee0PerLiquidity, fee0PerLiquidity);
+        assertEq(positionState_.fee1PerLiquidity, fee1PerLiquidity);
+        assertEq(positionState_.fee0, positionState.fee0);
+        assertEq(positionState_.fee1, positionState.fee1);
+        assertEq(positionState_.amountWrapped, 0);
+        assertEq(positionState_.pool, positionState.pool);
+    }
+
+    function testFuzz_Success_getFeeBalances_NonZeroTotalWrapped_CapDeltaFee1PerLiquidity(
+        WrappedAerodromeAM.PoolState memory poolState,
+        WrappedAerodromeAM.PositionState memory positionState,
+        uint256 fee0,
+        uint256 fee1
+    ) public view {
+        // Given: totalWrapped is bounded so mulDivDown does not overflow.
+        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, 1e18));
+
+        // And: deltaFee0PerLiquidity does not overflow.
+        fee0 = bound(fee0, 0, uint256(type(uint128).max) * poolState.totalWrapped / 1e18);
+
+        // And: deltaFee1PerLiquidity is bigger as type(uint128).max (capped instead of reverting).
+        fee1 = bound(fee1, uint256(type(uint128).max) * poolState.totalWrapped / 1e18 + 1, type(uint256).max / 1e18);
+
+        // And: no fees accrue to the position.
+        positionState.amountWrapped = 0;
+
+        // When : Calling _getFeeBalances().
+        (WrappedAerodromeAM.PoolState memory poolState_, WrappedAerodromeAM.PositionState memory positionState_) =
+            wrappedAerodromeAM.getFeeBalances(poolState, positionState, fee0, fee1);
+
+        // Then : deltaFee1PerLiquidity is capped at type(uint128).max.
+        uint128 fee0PerLiquidity;
+        uint128 fee1PerLiquidity;
+        unchecked {
+            fee0PerLiquidity = poolState.fee0PerLiquidity + uint128(fee0.mulDivDown(1e18, poolState.totalWrapped));
+            fee1PerLiquidity = poolState.fee1PerLiquidity + type(uint128).max;
+        }
+        assertEq(poolState_.fee0PerLiquidity, fee0PerLiquidity);
+        assertEq(poolState_.fee1PerLiquidity, fee1PerLiquidity);
+        assertEq(poolState_.totalWrapped, poolState.totalWrapped);
+
+        assertEq(positionState_.fee0PerLiquidity, fee0PerLiquidity);
+        assertEq(positionState_.fee1PerLiquidity, fee1PerLiquidity);
+        assertEq(positionState_.fee0, positionState.fee0);
+        assertEq(positionState_.fee1, positionState.fee1);
+        assertEq(positionState_.amountWrapped, 0);
+        assertEq(positionState_.pool, positionState.pool);
     }
 
     function testFuzz_Success_getFeeBalances_ZeroTotalWrapped(


### PR DESCRIPTION
Saturate the per-interaction reward/fee-per-liquidity deltas at type(uint128).max before the downcast, in AbstractStakingAM._getRewardBalances and WrappedAerodromeAM._getFeeBalances. Growth beyond the cap is discarded, but a realistic accrual never approaches it and every interaction resets the external balance.

Covers StakedAerodromeAM and StakedStargateAM via the shared AbstractStakingAM parent.

The _getRewardBalances / _getFeeBalances fuzz tests are updated to assert the saturating behaviour instead of a revert.