### PR TITLE
Only check out the submodules that are compiled

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -7,9 +7,12 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v5
+
+      - name: Check out the submodules that are compiled
+        run: |
+          git submodule update --init
+          git submodule update --init --recursive lib/slipstream lib/v4-periphery
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/foundryFuzz.yml
+++ b/.github/workflows/foundryFuzz.yml
@@ -10,9 +10,12 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v5
+
+      - name: Check out the submodules that are compiled
+        run: |
+          git submodule update --init
+          git submodule update --init --recursive lib/slipstream lib/v4-periphery
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
Recursing into every submodule clones trees that are never compiled. Also bumps actions/checkout to v5.