### PR TITLE
🚨 suppress intentional forge 1.8 lint findings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,6 @@ libs = ['lib']
 optimizer = true
 optimizer_runs = 200
 auto_detect_solc = true
-dynamic_test_linking = false
 isolate = false
 fuzz = { runs = 50, max_test_rejects = 100_000_000}
 no_match_path = "**/{script/,test/fork/}*"
@@ -31,7 +30,6 @@ remappings = [
     "lib/v4-periphery/lib/v4-core:@openzeppelin/=lib/v4-periphery/lib/v4-core/lib/openzeppelin-contracts/",
 ]
 fs_permissions = [{ access = "read", path = "./out"}, { access = "write", path = "./script/out"}]
-unchecked_cheatcode_artifacts = true
 # Transient storage composability warning (known safe pattern in AccountsGuard):
 # - 2394: transient storage cleared at end of call
 # Solmate deprecation warnings (used in deployed contracts):
@@ -60,7 +58,15 @@ tab_width = 4
 [lint]
 exclude_lints = [
     "asm-keccak256",
+    "calls-loop",
+    "missing-events-access-control",
+    "missing-zero-check",
+    "non-reentrant-not-first",
+    "reentrancy-events",
+    "require-revert-in-loop",
+    "uninitialized-local",
     "unsafe-cheatcode",
+    "unused-return",
     "unwrapped-modifier-logic",
 ]
 ignore = [

--- a/src/Factory.sol
+++ b/src/Factory.sol
@@ -102,6 +102,7 @@ contract Factory is IFactory, ERC721, FactoryGuardian {
         // Hash tx.origin with the user provided salt to avoid front-running Account deployment with an identical salt.
         // We use tx.origin instead of msg.sender so that deployments through third party contracts are not vulnerable to front-running.
         // 64 bit salt: 32 bits from tx.origin and 32 bits provided by the user.
+        // forge-lint: disable-next-item(unsafe-typecast)
         uint256 salt = uint256(keccak256(abi.encodePacked(userSalt, uint32(uint160(tx.origin)))));
         account = CreateProxyLib.createProxy(salt, versionInformation[accountVersion].implementation);
 
@@ -113,7 +114,7 @@ contract Factory is IFactory, ERC721, FactoryGuardian {
         IAccount(account).initialize(msg.sender, versionInformation[accountVersion].registry, creditor);
 
         // unsafe cast: accountVersion <= latestAccountVersion, which is a uint88.
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit AccountUpgraded(account, uint88(accountVersion));
     }
 
@@ -164,7 +165,7 @@ contract Factory is IFactory, ERC721, FactoryGuardian {
             );
 
         // unsafe cast: accountVersion <= latestAccountVersion, which is a uint88.
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit AccountUpgraded(account, uint88(version));
     }
 
@@ -384,6 +385,7 @@ contract Factory is IFactory, ERC721, FactoryGuardian {
      */
     // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
     function tokenURI(uint256 tokenId) public view override returns (string memory uri) {
+        // forge-lint: disable-next-item(encode-packed-collision)
         return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
     }
 }

--- a/src/Proxy.sol
+++ b/src/Proxy.sol
@@ -69,6 +69,7 @@ contract Proxy {
      * @return r The address stored in slot.
      */
     function _getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {
+        // forge-lint: disable-next-item(unsafe-typecast)
         assembly {
             r.slot := slot
         }

--- a/src/accounts/AccountPlaceholder.sol
+++ b/src/accounts/AccountPlaceholder.sol
@@ -77,6 +77,7 @@ contract AccountPlaceholder is AccountStorageV1, IAccount {
      * This prevents the old Owner from frontrunning a transferFrom().
      */
     modifier updateActionTimestamp() {
+        // forge-lint: disable-next-item(unsafe-typecast)
         lastActionTimestamp = uint32(block.timestamp);
         _;
     }

--- a/src/accounts/AccountStorageV1.sol
+++ b/src/accounts/AccountStorageV1.sol
@@ -20,28 +20,36 @@ abstract contract AccountStorageV1 {
     ////////////////////////////////////////////////////////////// */
 
     // Flag indicating if the Account is in an auction (in liquidation).
+    // forge-lint: disable-next-item(uninitialized-state)
     bool public inAuction;
     // Flag Indicating if a function is locked to protect against reentrancy.
     uint8 internal locked;
     // Used to prevent the old Owner from frontrunning a transferFrom().
     // The Timestamp of the last account action, that might be disadvantageous for a new Owner
     // (withdrawals, change of Creditor, increasing liabilities...).
+    // forge-lint: disable-next-item(uninitialized-state)
     uint32 public lastActionTimestamp;
     // The contract address of the liquidator, address 0 if no creditor is set.
+    // forge-lint: disable-next-item(uninitialized-state)
     address public liquidator;
 
     // The minimum amount of collateral that must be held in the Account before a position can be opened, denominated in the numeraire.
     // Will count as Used Margin after a position is opened.
+    // forge-lint: disable-next-item(uninitialized-state)
     uint96 public minimumMargin;
     // The contract address of the Registry.
+    // forge-lint: disable-next-item(uninitialized-state)
     address public registry;
 
     // The owner of the Account.
+    // forge-lint: disable-next-item(uninitialized-state)
     address public owner;
     // The contract address of the Creditor.
+    // forge-lint: disable-next-item(uninitialized-state)
     address public creditor;
     // The Numeraire (the unit in which prices are measured) of the Account,
     // in which all assets and liabilities are denominated.
+    // forge-lint: disable-next-item(uninitialized-state)
     address public numeraire;
 
     // Array with all the contract addresses of ERC20 tokens in the account.

--- a/src/accounts/AccountV3.sol
+++ b/src/accounts/AccountV3.sol
@@ -154,6 +154,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * This prevents the old Owner from frontrunning a transferFrom().
      */
     modifier updateActionTimestamp() {
+        // forge-lint: disable-next-item(unsafe-typecast)
         lastActionTimestamp = uint32(block.timestamp);
         _;
     }
@@ -251,6 +252,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @return r The address stored in slot.
      */
     function _getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {
+        // forge-lint: disable-next-item(unsafe-typecast)
         assembly {
             r.slot := slot
         }
@@ -264,6 +266,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @param data Arbitrary data, can contain instructions to execute in this function.
      * @dev If upgradeHook() is implemented, it MUST verify that msg.sender == address(this).
      */
+    // forge-lint: disable-next-item(empty-block)
     function upgradeHook(address oldImplementation, address oldRegistry, uint256 oldVersion, bytes calldata data)
         external { }
 
@@ -338,6 +341,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @dev Only open margin accounts for Creditors you trust!
      * The Creditor has significant authorization: use margin, trigger liquidation, and manage assets.
      */
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function openMarginAccount(address newCreditor)
         external
         onlyOwner
@@ -377,6 +381,8 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @notice Internal function: Opens a margin account for a new Creditor.
      * @param creditor_ The contract address of the Creditor.
      */
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _openMarginAccount(address creditor_) internal {
         (bool success, address numeraire_, address liquidator_, uint256 minimumMargin_) =
             ICreditor(creditor_).openMarginAccount(ACCOUNT_VERSION);
@@ -698,6 +704,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * - The Account is in a healthy state (collateral value is greater than open liabilities).
      * If a check fails, the whole transaction reverts.
      */
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function flashAction(address actionTarget, bytes calldata actionData)
         external
         onlyAssetManager
@@ -847,6 +854,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @dev This function can be used to refinance liabilities between different Creditors,
      * without the need to first sell collateral to close the open position of the old Creditor.
      */
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function flashActionByCreditor(bytes calldata callbackData, address actionTarget, bytes calldata actionData)
         external
         nonReentrant(WITH_PAUSE_CHECK)
@@ -1039,6 +1047,8 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @param to The address to withdraw to.
      * @dev (batch)ProcessWithdrawal handles the accounting of assets in the Registry.
      */
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _withdraw(
         address[] memory assetAddresses,
         uint256[] memory assetIds,
@@ -1083,6 +1093,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
      */
     // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
     function _depositERC20(address from, address ERC20Address, uint256 amount) internal {
+        // forge-lint: disable-next-item(arbitrary-send-erc20,solmate-safe-transfer-lib)
         ERC20(ERC20Address).safeTransferFrom(from, address(this), amount);
 
         uint256 currentBalance = erc20Balances[ERC20Address];
@@ -1124,7 +1135,8 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * If not, the function pushes the new address and ID to the stored arrays.
      * This may cause duplicates in the ERC1155 stored addresses array, this is intended.
      */
-    // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable,reentrancy-no-eth)
     function _depositERC1155(address from, address ERC1155Address, uint256 id, uint256 amount) internal {
         IERC1155(ERC1155Address).safeTransferFrom(from, address(this), id, amount, "");
 
@@ -1173,6 +1185,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
             }
         }
 
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(ERC20Address).safeTransfer(to, amount);
     }
 
@@ -1188,7 +1201,8 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * then replaces it with the last index, followed by a pop().
      * @dev Sensitive to ReEntrance attacks! SafeTransferFrom therefore done at the end of the function.
      */
-    // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable,reentrancy-no-eth)
     function _withdrawERC721(address to, address ERC721Address, uint256 id) internal {
         uint256 tokenIdLength = erc721TokenIds.length;
 
@@ -1231,7 +1245,8 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * and then replaces it with the last index, followed by a pop().
      * @dev Sensitive to ReEntrance attacks! SafeTransferFrom therefore done at the end of the function.
      */
-    // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable,reentrancy-no-eth)
     function _withdrawERC1155(address to, address ERC1155Address, uint256 id, uint256 amount) internal {
         uint256 tokenIdLength = erc1155TokenIds.length;
 
@@ -1264,6 +1279,8 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @param transferFromOwnerData A struct containing the info of all assets transferred from the owner that are not in this account.
      * @param to The address to withdraw to.
      */
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _transferFromOwner(ActionData memory transferFromOwnerData, address to) internal {
         uint256 assetAddressesLength = transferFromOwnerData.assets.length;
         // If no assets are being transferred, return early.
@@ -1277,6 +1294,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
             }
 
             if (transferFromOwnerData.assetTypes[i] == 1) {
+                // forge-lint: disable-next-item(arbitrary-send-erc20,solmate-safe-transfer-lib)
                 ERC20(transferFromOwnerData.assets[i])
                     .safeTransferFrom(owner_, to, transferFromOwnerData.assetAmounts[i]);
             } else if (transferFromOwnerData.assetTypes[i] == 2) {
@@ -1307,6 +1325,8 @@ contract AccountV3 is AccountStorageV1, IAccount {
      * @param signature The signature to verify.
      * @param to The address to withdraw to.
      */
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _transferFromOwnerWithPermit(
         IPermit2.PermitBatchTransferFrom memory permit,
         bytes memory signature,
@@ -1364,6 +1384,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
             uint256 balanceStored = erc20Balances[token];
             if (balance > balanceStored) {
                 amount = balance - balanceStored;
+                // forge-lint: disable-next-item(solmate-safe-transfer-lib)
                 ERC20(token).safeTransfer(msg.sender, amount);
             }
         } else if (type_ == 2) {

--- a/src/accounts/AccountV4.sol
+++ b/src/accounts/AccountV4.sol
@@ -112,6 +112,7 @@ contract AccountV4 is AccountStorageV1, IAccount {
      * This prevents the old Owner from frontrunning a transferFrom().
      */
     modifier updateActionTimestamp() {
+        // forge-lint: disable-next-item(unsafe-typecast)
         lastActionTimestamp = uint32(block.timestamp);
         _;
     }
@@ -464,6 +465,7 @@ contract AccountV4 is AccountStorageV1, IAccount {
             if (assetAmounts[i] == 0) continue;
 
             if (assetTypes[i] == 1) {
+                // forge-lint: disable-next-item(arbitrary-send-erc20,solmate-safe-transfer-lib)
                 ERC20(assetAddresses[i]).safeTransferFrom(from, address(this), assetAmounts[i]);
             } else if (assetTypes[i] == 2) {
                 IERC721(assetAddresses[i]).safeTransferFrom(from, address(this), assetIds[i]);
@@ -516,9 +518,11 @@ contract AccountV4 is AccountStorageV1, IAccount {
             if (assetAmounts[i] == 0) continue;
 
             if (assetAddresses[i] == address(0)) {
+                // forge-lint: disable-next-item(arbitrary-send-eth)
                 (bool success, bytes memory result) = payable(to).call{ value: assetAmounts[i] }("");
                 require(success, string(result));
             } else if (assetTypes[i] == 1) {
+                // forge-lint: disable-next-item(solmate-safe-transfer-lib)
                 ERC20(assetAddresses[i]).safeTransfer(to, assetAmounts[i]);
             } else if (assetTypes[i] == 2) {
                 IERC721(assetAddresses[i]).safeTransferFrom(address(this), to, assetIds[i]);
@@ -548,6 +552,7 @@ contract AccountV4 is AccountStorageV1, IAccount {
             if (transferFromOwnerData.assetAmounts[i] == 0) continue;
 
             if (transferFromOwnerData.assetTypes[i] == 1) {
+                // forge-lint: disable-next-item(arbitrary-send-erc20,solmate-safe-transfer-lib)
                 ERC20(transferFromOwnerData.assets[i])
                     .safeTransferFrom(owner_, to, transferFromOwnerData.assetAmounts[i]);
             } else if (transferFromOwnerData.assetTypes[i] == 2) {

--- a/src/asset-modules/Aerodrome-Finance/AerodromePoolAM.sol
+++ b/src/asset-modules/Aerodrome-Finance/AerodromePoolAM.sol
@@ -290,10 +290,12 @@ contract AerodromePoolAM is DerivedAM {
             // Stable aerodrome pools use a correction for the underlying token amounts to bring them to 18 decimals:
             // x = r0 * 10^(18 - D0).
             // y = r1 * 10^(18 - D1).
+            // forge-lint: disable-next-item(divide-before-multiply)
             uint256 x = reserve0 * unitCorrection0; // 18 decimals.
             uint256 y = reserve1 * unitCorrection1; // 18 decimals.
             uint256 a = x.mulDivDown(y, 1e18); // 18 decimals.
             uint256 b = (x * x + y * y) / 1e18; // 18 decimals.
+            // forge-lint: disable-next-item(divide-before-multiply)
             k = a * b; // 36 decimals.
         }
 
@@ -303,11 +305,14 @@ contract AerodromePoolAM is DerivedAM {
         // => x = √{p1 * √[c / d]}
         {
             // USD rates also have to be corrected as shown in 3).
+            // forge-lint: disable-next-item(divide-before-multiply)
             uint256 p0 = rateUnderlyingAssetsToUsd[0].assetValue / unitCorrection0; // 18 decimals.
             uint256 p1 = rateUnderlyingAssetsToUsd[1].assetValue / unitCorrection1; // 18 decimals.
             uint256 c = FullMath.mulDiv(k, p1, p0); // 36 decimals.
+            // forge-lint: disable-next-item(divide-before-multiply)
             uint256 d = p0 * p0 + p1 * p1; // 36 decimals.
             // Sqrt halves the number of decimals.
+            // forge-lint: disable-next-item(divide-before-multiply)
             uint256 x = FixedPointMathLib.sqrt(p1 * FixedPointMathLib.sqrt(FullMath.mulDiv(1e36, c, d))); // 18 decimals.
 
             // Bring reserve0 from 18 decimals precision to the actual token decimals.
@@ -353,11 +358,13 @@ contract AerodromePoolAM is DerivedAM {
 
         // Keep the lowest risk factor of all underlying assets.
         // Unsafe cast: collateralFactor and liquidationFactor are smaller than or equal to 1e4.
+        // forge-lint: disable-next-item(unsafe-typecast)
         collateralFactor = uint16(
             collateralFactors[0] < collateralFactors[1]
                 ? riskFactor.mulDivDown(collateralFactors[0], AssetValuationLib.ONE_4)
                 : riskFactor.mulDivDown(collateralFactors[1], AssetValuationLib.ONE_4)
         );
+        // forge-lint: disable-next-item(unsafe-typecast)
         liquidationFactor = uint16(
             liquidationFactors[0] < liquidationFactors[1]
                 ? riskFactor.mulDivDown(liquidationFactors[0], AssetValuationLib.ONE_4)

--- a/src/asset-modules/Aerodrome-Finance/WrappedAerodromeAM.sol
+++ b/src/asset-modules/Aerodrome-Finance/WrappedAerodromeAM.sol
@@ -294,6 +294,7 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
         if (token0[pool] == address(0)) revert PoolNotAllowed();
 
         // Need to transfer before minting or ERC777s could reenter.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(pool).safeTransferFrom(msg.sender, address(this), amount);
 
         // Cache the old poolState.
@@ -341,6 +342,7 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
         PoolState memory poolState_ = poolState[pool];
 
         // Need to transfer before increasing liquidity or ERC777s could reenter.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(pool).safeTransferFrom(msg.sender, address(this), amount);
 
         // Claim any pending fees from the Aerodrome Pool.
@@ -419,12 +421,15 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
         poolState[pool] = poolState_;
 
         // Pay out the fees to the position owner.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (fee0Position > 0) ERC20(token0[pool]).safeTransfer(msg.sender, fee0Position);
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (fee1Position > 0) ERC20(token1[pool]).safeTransfer(msg.sender, fee1Position);
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit FeesPaid(positionId, uint128(fee0Position), uint128(fee1Position));
 
         // Transfer the liquidity back to the position owner.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(pool).safeTransfer(msg.sender, amount);
         emit LiquidityDecreased(positionId, pool, amount);
     }
@@ -461,9 +466,11 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
         poolState[pool] = poolState_;
 
         // Pay out the fees to the position owner.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (fee0Position > 0) ERC20(token0[pool]).safeTransfer(msg.sender, fee0Position);
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (fee1Position > 0) ERC20(token1[pool]).safeTransfer(msg.sender, fee1Position);
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit FeesPaid(positionId, uint128(fee0Position), uint128(fee1Position));
     }
 
@@ -492,6 +499,7 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
 
         // Transfer excess funds to the owner.
         uint256 deltaWrapped = ERC20(pool).balanceOf(address(this)) - poolState_.totalWrapped;
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(pool).safeTransfer(msg.sender, deltaWrapped);
     }
 
@@ -514,6 +522,8 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
      * @return fee0 The amount of fees of token0 claimed.
      * @return fee1 The amount of fees of token1 claimed.
      */
+    // Reentrancy is blocked by the nonReentrant guard on every caller.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _claimFees(address pool) internal returns (uint256 fee0, uint256 fee1) {
         (fee0, fee1) = IAeroPool(pool).claimFees();
     }
@@ -643,6 +653,7 @@ contract WrappedAerodromeAM is DerivedAM, ERC721, ReentrancyGuard {
      */
     // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
     function tokenURI(uint256 tokenId) public view override returns (string memory uri) {
+        // forge-lint: disable-next-item(encode-packed-collision)
         return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
     }
 }

--- a/src/asset-modules/Slipstream/SlipstreamAM.sol
+++ b/src/asset-modules/Slipstream/SlipstreamAM.sol
@@ -248,6 +248,7 @@ contract SlipstreamAM is DerivedAM {
         // For deposited assets, the liquidity of the Liquidity Position is stored in the Asset Module,
         // not fetched from the NonfungiblePositionManager.
         // Since liquidity of a position can be increased by a non-owner, the max exposure checks could otherwise be circumvented.
+        // forge-lint: disable-next-item(unsafe-typecast)
         liquidity = uint128(assetToLiquidity[assetId]);
 
         if (liquidity > 0) {
@@ -309,6 +310,7 @@ contract SlipstreamAM is DerivedAM {
 
         // Change sqrtPrice from a decimal fixed point number with 14 digits to a binary fixed point number with 96 digits.
         // Unsafe cast: Cast will only overflow when priceToken0/priceToken1 >= 2^128.
+        // forge-lint: disable-next-item(unsafe-typecast)
         sqrtPriceX96 = uint160((sqrtPriceXd14 << FixedPoint96.RESOLUTION) / 1e14);
     }
 
@@ -426,11 +428,13 @@ contract SlipstreamAM is DerivedAM {
 
         // Keep the lowest risk factor of all underlying assets.
         // Unsafe cast: collateralFactor and liquidationFactor are smaller than or equal to 1e4.
+        // forge-lint: disable-next-item(unsafe-typecast)
         collateralFactor = uint16(
             collateralFactors[0] < collateralFactors[1]
                 ? riskFactor.mulDivDown(collateralFactors[0], AssetValuationLib.ONE_4)
                 : riskFactor.mulDivDown(collateralFactors[1], AssetValuationLib.ONE_4)
         );
+        // forge-lint: disable-next-item(unsafe-typecast)
         liquidationFactor = uint16(
             liquidationFactors[0] < liquidationFactors[1]
                 ? riskFactor.mulDivDown(liquidationFactors[0], AssetValuationLib.ONE_4)

--- a/src/asset-modules/Slipstream/StakedSlipstreamAM.sol
+++ b/src/asset-modules/Slipstream/StakedSlipstreamAM.sol
@@ -288,6 +288,7 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
 
         // Change sqrtPrice from a decimal fixed point number with 14 digits to a binary fixed point number with 96 digits.
         // Unsafe cast: Cast will only overflow when priceToken0/priceToken1 >= 2^128.
+        // forge-lint: disable-next-item(unsafe-typecast)
         sqrtPriceX96 = uint160((sqrtPriceXd14 << FixedPoint96.RESOLUTION) / 1e14);
     }
 
@@ -390,6 +391,7 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
      * @return positionId The id of the Minted Position.
      * @dev the Minted Position has the same id as the Liquidity Position.
      */
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function mint(uint256 assetId) external nonReentrant returns (uint256 positionId) {
         if (assetId > type(uint96).max) revert InvalidId();
         NON_FUNGIBLE_POSITION_MANAGER.safeTransferFrom(msg.sender, address(this), assetId);
@@ -429,7 +431,9 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
         // these were claimed during the deposit and send to this contract.
         uint256 balance0 = ERC20(token0).balanceOf(address(this));
         uint256 balance1 = ERC20(token1).balanceOf(address(this));
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (balance0 > 0) ERC20(token0).safeTransfer(msg.sender, balance0);
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (balance1 > 0) ERC20(token1).safeTransfer(msg.sender, balance1);
 
         // Mint the new position, with same id as the underlying position.
@@ -442,6 +446,7 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
      * @param positionId The id of the position.
      * @return rewards The amount of reward tokens claimed.
      */
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function burn(uint256 positionId) external nonReentrant returns (uint256 rewards) {
         if (_ownerOf[positionId] != msg.sender) revert NotOwner();
 
@@ -456,8 +461,9 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
         // Pay out the rewards to the position owner.
         if (rewards > 0) {
             // Transfer reward
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             REWARD_TOKEN.safeTransfer(msg.sender, rewards);
-            // forge-lint: disable-next-line(unsafe-typecast)
+            // forge-lint: disable-next-item(unsafe-typecast)
             emit RewardPaid(positionId, address(REWARD_TOKEN), uint128(rewards));
         }
 
@@ -470,6 +476,7 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
      * @param positionId The id of the position.
      * @return rewards The amount of reward tokens claimed.
      */
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function claimReward(uint256 positionId) external nonReentrant returns (uint256 rewards) {
         if (_ownerOf[positionId] != msg.sender) revert NotOwner();
 
@@ -480,8 +487,9 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
         // Pay out the rewards to the position owner.
         if (rewards > 0) {
             // Transfer reward
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             REWARD_TOKEN.safeTransfer(msg.sender, rewards);
-            // forge-lint: disable-next-line(unsafe-typecast)
+            // forge-lint: disable-next-item(unsafe-typecast)
             emit RewardPaid(positionId, address(REWARD_TOKEN), uint128(rewards));
         }
     }
@@ -515,6 +523,7 @@ contract StakedSlipstreamAM is DerivedAM, ERC721, ReentrancyGuard {
      */
     // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
     function tokenURI(uint256 tokenId) public view override returns (string memory uri) {
+        // forge-lint: disable-next-item(encode-packed-collision)
         return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
     }
 

--- a/src/asset-modules/Stargate-Finance/StargateAM.sol
+++ b/src/asset-modules/Stargate-Finance/StargateAM.sol
@@ -189,7 +189,9 @@ contract StargateAM is DerivedAM {
         uint256 riskFactor = riskParams[creditor].riskFactor;
 
         // Lower risk factors with the protocol wide risk factor.
+        // forge-lint: disable-next-item(unsafe-typecast)
         collateralFactor = uint16(riskFactor.mulDivDown(collateralFactors[0], AssetValuationLib.ONE_4));
+        // forge-lint: disable-next-item(unsafe-typecast)
         liquidationFactor = uint16(riskFactor.mulDivDown(liquidationFactors[0], AssetValuationLib.ONE_4));
     }
 

--- a/src/asset-modules/UniswapV3/UniswapV3AM.sol
+++ b/src/asset-modules/UniswapV3/UniswapV3AM.sol
@@ -248,6 +248,7 @@ contract UniswapV3AM is DerivedAM {
         // For deposited assets, the liquidity of the Liquidity Position is stored in the Asset Module,
         // not fetched from the NonfungiblePositionManager.
         // Since liquidity of a position can be increased by a non-owner, the max exposure checks could otherwise be circumvented.
+        // forge-lint: disable-next-item(unsafe-typecast)
         liquidity = uint128(assetToLiquidity[assetId]);
 
         if (liquidity > 0) {
@@ -309,6 +310,7 @@ contract UniswapV3AM is DerivedAM {
 
         // Change sqrtPrice from a decimal fixed point number with 14 digits to a binary fixed point number with 96 digits.
         // Unsafe cast: Cast will only overflow when priceToken0/priceToken1 >= 2^128.
+        // forge-lint: disable-next-item(unsafe-typecast)
         sqrtPriceX96 = uint160((sqrtPriceXd14 << FixedPoint96.RESOLUTION) / 1e14);
     }
 
@@ -426,11 +428,13 @@ contract UniswapV3AM is DerivedAM {
 
         // Keep the lowest risk factor of all underlying assets.
         // Unsafe cast: collateralFactor and liquidationFactor are smaller than or equal to 1e4.
+        // forge-lint: disable-next-item(unsafe-typecast)
         collateralFactor = uint16(
             collateralFactors[0] < collateralFactors[1]
                 ? riskFactor.mulDivDown(collateralFactors[0], AssetValuationLib.ONE_4)
                 : riskFactor.mulDivDown(collateralFactors[1], AssetValuationLib.ONE_4)
         );
+        // forge-lint: disable-next-item(unsafe-typecast)
         liquidationFactor = uint16(
             liquidationFactors[0] < liquidationFactors[1]
                 ? riskFactor.mulDivDown(liquidationFactors[0], AssetValuationLib.ONE_4)

--- a/src/asset-modules/UniswapV4/DefaultUniswapV4AM.sol
+++ b/src/asset-modules/UniswapV4/DefaultUniswapV4AM.sol
@@ -298,6 +298,7 @@ contract DefaultUniswapV4AM is DerivedAM {
 
         // Change sqrtPrice from a decimal fixed point number with 14 digits to a binary fixed point number with 96 digits.
         // Unsafe cast: Cast will only overflow when priceToken0/priceToken1 >= 2^128.
+        // forge-lint: disable-next-item(unsafe-typecast)
         sqrtPriceX96 = uint160((sqrtPriceXd14 << FixedPoint96.RESOLUTION) / 1e14);
     }
 
@@ -371,11 +372,13 @@ contract DefaultUniswapV4AM is DerivedAM {
 
         // Keep the lowest risk factor of all underlying assets.
         // Unsafe cast: collateralFactor and liquidationFactor are smaller than or equal to 1e4.
+        // forge-lint: disable-next-item(unsafe-typecast)
         collateralFactor = uint16(
             collateralFactors[0] < collateralFactors[1]
                 ? riskFactor.mulDivDown(collateralFactors[0], AssetValuationLib.ONE_4)
                 : riskFactor.mulDivDown(collateralFactors[1], AssetValuationLib.ONE_4)
         );
+        // forge-lint: disable-next-item(unsafe-typecast)
         liquidationFactor = uint16(
             liquidationFactors[0] < liquidationFactors[1]
                 ? riskFactor.mulDivDown(liquidationFactors[0], AssetValuationLib.ONE_4)

--- a/src/asset-modules/abstracts/AbstractAM.sol
+++ b/src/asset-modules/abstracts/AbstractAM.sol
@@ -111,6 +111,7 @@ abstract contract AssetModule is Owned, IAssetModule {
     function _getAssetFromKey(bytes32 key) internal view virtual returns (address asset, uint256 assetId) {
         assembly {
             // Shift to the right by 20 bytes (160 bits) to extract the uint96 assetId.
+            // forge-lint: disable-next-item(unsafe-typecast)
             assetId := shr(160, key)
 
             // Use bitmask to extract the address from the rightmost 160 bits.

--- a/src/asset-modules/abstracts/AbstractDerivedAM.sol
+++ b/src/asset-modules/abstracts/AbstractDerivedAM.sol
@@ -359,6 +359,8 @@ abstract contract DerivedAM is AssetModule {
      * @dev The checks on exposures are only done to block deposits that would over-expose a Creditor to a certain asset or protocol.
      * Underflows will not revert, but the exposure is instead set to 0.
      */
+    // Reentrancy is blocked by the Registry, the only caller of the entry points.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _processDeposit(uint256 exposureAsset, address creditor, bytes32 assetKey)
         internal
         virtual
@@ -381,7 +383,9 @@ abstract contract DerivedAM is AssetModule {
 
             for (uint256 i; i < underlyingAssetKeys.length; ++i) {
                 // Calculate the change in exposure to the underlying assets since last interaction.
+                // forge-lint: disable-next-item(unsafe-typecast)
                 deltaExposureAssetToUnderlyingAsset = int256(exposureAssetToUnderlyingAssets[i])
+                    // forge-lint: disable-next-item(unsafe-typecast)
                     - int256(lastExposureAssetToUnderlyingAsset[creditor][assetKey][i]);
 
                 // Update "lastExposureAssetToUnderlyingAsset".
@@ -450,6 +454,8 @@ abstract contract DerivedAM is AssetModule {
      * As such the actual exposure on a withdrawal of a derived asset can exceed the maxExposure, but this should never be blocked,
      * (the withdrawal actually improves the situation by making the asset less over-exposed).
      */
+    // Reentrancy is blocked by the Registry, the only caller of the entry points.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _processWithdrawal(address creditor, bytes32 assetKey, uint256 exposureAsset)
         internal
         virtual
@@ -468,7 +474,9 @@ abstract contract DerivedAM is AssetModule {
 
         for (uint256 i; i < underlyingAssetKeys.length; ++i) {
             // Calculate the change in exposure to the underlying assets since last interaction.
+            // forge-lint: disable-next-item(unsafe-typecast)
             deltaExposureAssetToUnderlyingAsset = int256(exposureAssetToUnderlyingAssets[i])
+                // forge-lint: disable-next-item(unsafe-typecast)
                 - int256(lastExposureAssetToUnderlyingAsset[creditor][assetKey][i]);
 
             // Update "lastExposureAssetToUnderlyingAsset".

--- a/src/asset-modules/abstracts/AbstractStakingAM.sol
+++ b/src/asset-modules/abstracts/AbstractStakingAM.sol
@@ -290,6 +290,7 @@ abstract contract StakingAM is DerivedAM, ERC721, ReentrancyGuard {
         if (amount == 0) revert ZeroAmount();
 
         // Need to transfer before minting or ERC777s could reenter.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
 
         // Cache the old assetState.
@@ -338,6 +339,7 @@ abstract contract StakingAM is DerivedAM, ERC721, ReentrancyGuard {
         AssetState memory assetState_ = assetState[asset];
 
         // Need to transfer before increasing liquidity or ERC777s could reenter.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
 
         // Calculate the new reward balances.
@@ -413,12 +415,14 @@ abstract contract StakingAM is DerivedAM, ERC721, ReentrancyGuard {
         // Pay out the rewards to the position owner.
         if (rewards > 0) {
             // Transfer reward
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             REWARD_TOKEN.safeTransfer(msg.sender, rewards);
             // forge-lint: disable-next-line(unsafe-typecast)
             emit RewardPaid(positionId, address(REWARD_TOKEN), uint128(rewards));
         }
 
         // Transfer the asset back to the position owner.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(asset).safeTransfer(msg.sender, amount);
         emit LiquidityDecreased(positionId, asset, amount);
     }
@@ -454,6 +458,7 @@ abstract contract StakingAM is DerivedAM, ERC721, ReentrancyGuard {
         // Pay out the share of the reward owed to the position owner.
         if (rewards > 0) {
             // Transfer reward
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             REWARD_TOKEN.safeTransfer(msg.sender, rewards);
             // forge-lint: disable-next-line(unsafe-typecast)
             emit RewardPaid(positionId, address(REWARD_TOKEN), uint128(rewards));
@@ -591,6 +596,7 @@ abstract contract StakingAM is DerivedAM, ERC721, ReentrancyGuard {
      */
     // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory uri) {
+        // forge-lint: disable-next-item(encode-packed-collision)
         return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
     }
 }

--- a/src/guardians/BaseGuardian.sol
+++ b/src/guardians/BaseGuardian.sol
@@ -22,6 +22,7 @@ abstract contract BaseGuardian is Owned {
     ////////////////////////////////////////////////////////////// */
 
     // Last timestamp an emergency stop was triggered.
+    // forge-lint: disable-next-item(uninitialized-state)
     uint96 public pauseTimestamp;
     // Address of the Guardian.
     address public guardian;

--- a/src/guardians/RegistryGuardian.sol
+++ b/src/guardians/RegistryGuardian.sol
@@ -70,6 +70,7 @@ abstract contract RegistryGuardian is BaseGuardian {
      * - Deposit assets.
      */
     function pause() external override onlyGuardian afterCoolDownOf(1441 minutes) {
+        // forge-lint: disable-next-item(unsafe-typecast)
         pauseTimestamp = uint96(block.timestamp);
         emit PauseFlagsUpdated(withdrawPaused = true, depositPaused = true);
     }

--- a/src/libraries/CreateProxyLib.sol
+++ b/src/libraries/CreateProxyLib.sol
@@ -35,6 +35,7 @@ library CreateProxyLib {
      */
     function createProxy(uint256 salt, address implementation) internal returns (address proxy) {
         bytes memory runtimeBytecode = abi.encodePacked(PROXY_BYTECODE, implementation);
+        // forge-lint: disable-next-item(unsafe-typecast)
         assembly {
             proxy := create2(0, add(runtimeBytecode, 0x20), mload(runtimeBytecode), salt)
         }

--- a/src/libraries/Strings.sol
+++ b/src/libraries/Strings.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.34;
 
-// forge-lint: disable-next-item(unsafe-typecast)
 library Strings {
     /**
      * @dev Converts a `uint256` to its ASCII `string` decimal representation.
@@ -22,6 +21,7 @@ library Strings {
         bytes memory buffer = new bytes(digits);
         while (value != 0) {
             digits -= 1;
+            // forge-lint: disable-next-item(unsafe-typecast)
             buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
             value /= 10;
         }

--- a/src/oracle-modules/ChainlinkOM.sol
+++ b/src/oracle-modules/ChainlinkOM.sol
@@ -78,6 +78,7 @@ contract ChainlinkOM is OracleModule {
 
         oracleToOracleId[oracle] = oracleId;
         assetPair[oracleId] = AssetPair({ baseAsset: baseAsset, quoteAsset: quoteAsset });
+        // forge-lint: disable-next-item(unsafe-typecast)
         oracleInformation[oracleId] = OracleInformation({
             cutOffTime: cutOffTime, unitCorrection: uint64(10 ** (18 - decimals)), oracle: oracle
         });

--- a/test/CompilePragma8Dot26.t.sol
+++ b/test/CompilePragma8Dot26.t.sol
@@ -12,5 +12,6 @@ import { Test } from "../lib/forge-std/src/Test.sol";
 // forge-lint: disable-end(unused-import)
 
 contract CompilePragma8Dot26 is Test {
+    // forge-lint: disable-next-item(empty-block)
     function test() public { }
 }

--- a/test/fuzz/Factory/AllAccountsLength.fuzz.t.sol
+++ b/test/fuzz/Factory/AllAccountsLength.fuzz.t.sol
@@ -16,6 +16,7 @@ contract AllAccountsLength_Factory_Fuzz_Test is Factory_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/Factory/BlockAccountVersion.fuzz.t.sol
+++ b/test/fuzz/Factory/BlockAccountVersion.fuzz.t.sol
@@ -7,10 +7,12 @@ pragma solidity ^0.8.0;
 import { Factory } from "../../../src/Factory.sol";
 import { Factory_Fuzz_Test } from "./_Factory.fuzz.t.sol";
 import { FactoryErrors } from "../../../src/libraries/Errors.sol";
+
 /**
  * @notice Fuzz tests for the function "blockAccountVersion" of contract "Factory".
  */
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BlockAccountVersion_Factory_Fuzz_Test is Factory_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -58,7 +60,7 @@ contract BlockAccountVersion_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
         vm.startPrank(users.owner);
         vm.expectEmit(true, true, true, true);
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit Factory.AccountVersionBlocked(uint88(accountVersion));
         factory.blockAccountVersion(accountVersion);
         vm.stopPrank();

--- a/test/fuzz/Factory/CreateAccount.fuzz.t.sol
+++ b/test/fuzz/Factory/CreateAccount.fuzz.t.sol
@@ -19,6 +19,7 @@ import { Utils } from "../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "createAccount" of contract "Factory".
  */
+// forge-lint: disable-next-item(weak-prng)
 contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/Factory/SetBaseURI.fuzz.t.sol
+++ b/test/fuzz/Factory/SetBaseURI.fuzz.t.sol
@@ -49,6 +49,7 @@ contract SetBaseURI_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
         string memory actualUri = factory.tokenURI(id);
 
+        // forge-lint: disable-next-item(encode-packed-collision)
         assertEq(actualUri, string(abi.encodePacked(uri, id.toString())));
     }
 }

--- a/test/fuzz/Factory/SetNewAccountInfo.fuzz.t.sol
+++ b/test/fuzz/Factory/SetNewAccountInfo.fuzz.t.sol
@@ -15,6 +15,7 @@ import { RegistryL2, RegistryL2Extension } from "../../utils/extensions/Registry
 /**
  * @notice Fuzz tests for the function "setNewAccountInfo" of contract "Factory".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetNewAccountInfo_Factory_Fuzz_Test is Factory_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               VARIABLES
@@ -149,7 +150,7 @@ contract SetNewAccountInfo_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
         vm.startPrank(users.owner);
         vm.expectEmit(true, true, true, true);
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit Factory.AccountVersionAdded(uint16(latestAccountVersionPre + 1), address(registry2), logic);
         factory.setNewAccountInfo(address(registry2), logic, Constants.ROOT, data);
         vm.stopPrank();

--- a/test/fuzz/Factory/TransferFrom.fuzz.sol
+++ b/test/fuzz/Factory/TransferFrom.fuzz.sol
@@ -36,6 +36,7 @@ contract TransferFrom_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
     function coolDownPeriodPassed(address account_, uint32 lastActionTimestamp, uint32 timePassed) public {
         AccountV3 _account_ = AccountV3(account_);
+        // forge-lint: disable-next-item(unsafe-typecast)
         timePassed = uint32(bound(timePassed, coolDownPeriod + 1, type(uint32).max));
 
         vm.warp(lastActionTimestamp);

--- a/test/fuzz/Fuzz.t.sol
+++ b/test/fuzz/Fuzz.t.sol
@@ -27,6 +27,7 @@ import { NativeTokenAMExtension } from "../utils/extensions/NativeTokenAMExtensi
  * (eg. a uint256 from 0 to type(uint256).max), unless the parameter/variable is bound by an invariant.
  * If this case, said invariant must be explicitly tested in the invariant tests.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 abstract contract Fuzz_Test is Base_Test, ArcadiaAccountsFixture {
     /*//////////////////////////////////////////////////////////////////////////
                                      VARIABLES

--- a/test/fuzz/accounts/AccountPlaceholder/Constructor.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountPlaceholder/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_AccountPlaceholder_Fuzz_Test is AccountPlaceholder_Fuzz_Tes
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/accounts/AccountPlaceholder/TransferOwnership.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountPlaceholder/TransferOwnership.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AccountsGuard } from "../../../../src/accounts/helpers/AccountsGuard.so
 /**
  * @notice Fuzz tests for the function "transferOwnership" of contract "AccountPlaceholder".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract TransferOwnership_AccountPlaceholder_Fuzz_Test is AccountPlaceholder_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/accounts/AccountV3/AuctionBid.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/AuctionBid.fuzz.t.sol
@@ -15,6 +15,7 @@ import { stdError } from "../../../../lib/forge-std/src/StdError.sol";
 /**
  * @notice Fuzz tests for the "auctionBid" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AuctionBid_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/accounts/AccountV3/CloseMarginAccount.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/CloseMarginAccount.fuzz.t.sol
@@ -13,6 +13,7 @@ import { CreditorMock } from "../../../utils/mocks/creditors/CreditorMock.sol";
 /**
  * @notice Fuzz tests for the function "closeMarginAccount" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CloseMarginAccount_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                             TEST CONTRACTS

--- a/test/fuzz/accounts/AccountV3/Constructor.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/accounts/AccountV3/Deposit.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/Deposit.fuzz.t.sol
@@ -13,6 +13,7 @@ import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "deposit" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Deposit_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                             TEST CONTRACTS

--- a/test/fuzz/accounts/AccountV3/FlashAction.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/FlashAction.fuzz.t.sol
@@ -24,6 +24,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "flashAction" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(divide-before-multiply,incorrect-strict-equality,unsafe-typecast)
 contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/accounts/AccountV3/FlashActionByCreditor.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/FlashActionByCreditor.fuzz.t.sol
@@ -25,6 +25,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "flashActionByCreditor" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract FlashActionByCreditor_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -776,6 +777,7 @@ contract FlashActionByCreditor_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permi
         }
 
         // Assert the accountExtension has no TOKEN2 balance initially
+        // forge-lint: disable-next-item(incorrect-strict-equality)
         assert(mockERC20.token2.balanceOf(address(accountExtension)) == 0);
 
         vm.warp(time);

--- a/test/fuzz/accounts/AccountV3/GetAccountValue.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/GetAccountValue.fuzz.t.sol
@@ -27,6 +27,7 @@ contract GetAccountValue_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getAccountValue(uint112 spotValue) public {
         // Given: "exposure" is strictly smaller than "maxExposure".
+        // forge-lint: disable-next-item(unsafe-typecast)
         spotValue = uint112(bound(spotValue, 0, type(uint112).max - 1));
 
         // Set Spot Value of assets (value of stable1 is 1:1 the amount of stable1 tokens).

--- a/test/fuzz/accounts/AccountV3/GetCollateralValue.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/GetCollateralValue.fuzz.t.sol
@@ -10,6 +10,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getCollateralValue" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetCollateralValue_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                             TEST CONTRACTS

--- a/test/fuzz/accounts/AccountV3/GetLiquidationValue.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/GetLiquidationValue.fuzz.t.sol
@@ -10,6 +10,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getLiquidationValue" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetLiquidationValue_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                             TEST CONTRACTS

--- a/test/fuzz/accounts/AccountV3/OpenMarginAccount.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/OpenMarginAccount.fuzz.t.sol
@@ -14,6 +14,7 @@ import { Constants } from "../../../utils/Constants.sol";
 /**
  * @notice Fuzz tests for the function "openMarginAccount" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract OpenMarginAccount_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/accounts/AccountV3/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/StartLiquidation.fuzz.t.sol
@@ -16,6 +16,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the "startLiquidation" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract startLiquidation_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/accounts/AccountV3/TransferOwnership.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/TransferOwnership.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AccountV3_Fuzz_Test } from "./_AccountV3.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "transferOwnership" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract TransferOwnership_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/accounts/AccountV3/UpgradeAccount.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/UpgradeAccount.fuzz.t.sol
@@ -16,6 +16,7 @@ import { RegistryL2Extension } from "../../../utils/extensions/RegistryL2Extensi
 /**
  * @notice Fuzz tests for the function "upgradeAccount" of contract "AccountV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract UpgradeAccount_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               VARIABLES

--- a/test/fuzz/accounts/AccountV4/Constructor.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/accounts/AccountV4/Deposit.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/Deposit.fuzz.t.sol
@@ -134,6 +134,7 @@ contract Deposit_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
 
         // When: Native ETH is deposited into spot Account.
         vm.prank(users.accountOwner);
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         accountSpot.deposit{ value: amount }(new address[](0), new uint256[](0), new uint256[](0), new uint256[](0));
 
         // Then : It should return the correct balance.

--- a/test/fuzz/accounts/AccountV4/FlashAction.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/FlashAction.fuzz.t.sol
@@ -22,6 +22,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "flashAction" of contract "AccountV4".
  */
+// forge-lint: disable-next-item(divide-before-multiply)
 contract FlashAction_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test, Permit2Fixture {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -683,6 +684,7 @@ contract FlashAction_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test, Permit2Fixture 
 
         // When: Native ETH is deposited into spot Account.
         vm.prank(users.accountOwner);
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         accountSpot.flashAction{ value: amount }(address(actionTarget), callData);
 
         // Then : It should return the correct balance.

--- a/test/fuzz/accounts/AccountV4/TransferOwnership.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/TransferOwnership.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AccountV4_Fuzz_Test } from "./_AccountV4.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "transferOwnership" of contract "AccountV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract TransferOwnership_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/accounts/AccountV4/UpgradeHook.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/UpgradeHook.fuzz.t.sol
@@ -14,6 +14,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "upgradeHook" of contract "AccountV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract UpgradeHook_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/accounts/AccountV4/Withdraw.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/Withdraw.fuzz.t.sol
@@ -118,8 +118,10 @@ contract Withdraw_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
 
     function testFuzz_Success_withdraw_ETH(uint112 ethAmount) public {
         // Given : Initial amount of ETH sent to the Spot Account
+        // forge-lint: disable-next-item(unsafe-typecast)
         ethAmount = uint112(bound(ethAmount, 1, 100 ether));
         vm.prank(users.accountOwner);
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         (bool success,) = payable(address(accountSpot)).call{ value: ethAmount }("");
         assertEq(success, true);
         assertEq(address(accountSpot).balance, ethAmount);

--- a/test/fuzz/accounts/Helpers/SpotToMarginMigrator/EndUpgrade.fuzz.t..sol
+++ b/test/fuzz/accounts/Helpers/SpotToMarginMigrator/EndUpgrade.fuzz.t..sol
@@ -11,6 +11,7 @@ import { SpotToMarginMigrator_Fuzz_Test } from "./_SpotToMarginMigrator.fuzz.t.s
 /**
  * @notice Fuzz tests for the function "endUpgrade" of contract "SpotToMarginMigrator".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract EndUpgrade_SpotToMarginMigrator_Fuzz_Test is SpotToMarginMigrator_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               TEST CONTRACTS

--- a/test/fuzz/accounts/Helpers/SpotToMarginMigrator/UpgradeAccount.fuzz.t.sol
+++ b/test/fuzz/accounts/Helpers/SpotToMarginMigrator/UpgradeAccount.fuzz.t.sol
@@ -13,6 +13,7 @@ import { SpotToMarginMigrator_Fuzz_Test } from "./_SpotToMarginMigrator.fuzz.t.s
 /**
  * @notice Fuzz tests for the function "upgradeAccount" of contract "SpotToMarginMigrator".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract UpgradeAccount_SpotToMarginMigrator_Fuzz_Test is SpotToMarginMigrator_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                          TEST CONTRACTS

--- a/test/fuzz/asset-modules/AbstractAM/GetAssetFromKey.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractAM/GetAssetFromKey.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetAssetFromKey_AbstractAM_Fuzz_Test is AbstractAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getAssetFromKey(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 key = bytes32(abi.encodePacked(assetId, asset));
         (address actualAsset, uint256 actualAssetId) = assetModule.getAssetFromKey(key);
 

--- a/test/fuzz/asset-modules/AbstractAM/GetKeyFromAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractAM/GetKeyFromAsset.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetKeyFromAsset_AbstractAM_Fuzz_Test is AbstractAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getKeyFromAsset(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 expectedKey = bytes32(abi.encodePacked(assetId, asset));
         bytes32 actualKey = assetModule.getKeyFromAsset(asset, assetId);
 

--- a/test/fuzz/asset-modules/AbstractDerivedAM/GetRateUnderlyingAssetsToUsd.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/GetRateUnderlyingAssetsToUsd.fuzz.t.sol
@@ -38,6 +38,7 @@ contract GetRateUnderlyingAssetsToUsd_AbstractDerivedAM_Fuzz_Test is AbstractDer
 
         // Prepare input.
         bytes32[] memory underlyingAssetKeys = new bytes32[](1);
+        // forge-lint: disable-next-item(unsafe-typecast)
         underlyingAssetKeys[0] =
             bytes32(abi.encodePacked(uint96(assetState.underlyingAssetId), assetState.underlyingAsset));
 

--- a/test/fuzz/asset-modules/AbstractDerivedAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/GetRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "AbstractDerivedAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetRiskFactors_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
@@ -10,7 +10,7 @@ import { AssetModule } from "../../../../src/asset-modules/abstracts/AbstractAM.
 /**
  * @notice Fuzz tests for the function "_processDeposit" of contract "AbstractDerivedAM".
  */
-// forge-lint: disable-next-item(mixed-case-variable)
+// forge-lint: disable-next-item(mixed-case-variable,unsafe-typecast)
 contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
@@ -9,7 +9,7 @@ import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_processWithdrawal" of contract "AbstractDerivedAM".
  */
-// forge-lint: disable-next-item(mixed-case-variable)
+// forge-lint: disable-next-item(mixed-case-variable,unsafe-typecast)
 contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AbstractDerivedAM/SetRiskParameters.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/SetRiskParameters.fuzz.t.sol
@@ -13,6 +13,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "setRiskParameters" of contract "AbstractDerivedAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetRiskParameters_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/GetRiskFactors.fuzz.t.sol
@@ -10,6 +10,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "AbstractPrimaryAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetRiskFactors_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/SetRiskParameters.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/SetRiskParameters.fuzz.t.sol
@@ -12,6 +12,7 @@ import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrima
 /**
  * @notice Fuzz tests for the function "setRiskParameters" of contract "AbstractPrimaryAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetRiskParameters_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AbstractStakingAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "StakingAM".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract CalculateValueAndRiskFactors_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AbstractStakingAM/ClaimReward.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/ClaimReward.fuzz.t.sol
@@ -10,6 +10,7 @@ import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointM
 /**
  * @notice Fuzz tests for the function "claimReward" of contract "StakingAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ClaimReward_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
 
@@ -72,7 +73,7 @@ contract ClaimReward_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test 
         // When : Account calls claimReward()
         vm.startPrank(account_);
         vm.expectEmit();
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit StakingAM.RewardPaid(positionId, address(stakingAM.REWARD_TOKEN()), uint128(currentRewardPosition));
         uint256 rewards = stakingAM.claimReward(positionId);
         vm.stopPrank();
@@ -95,6 +96,7 @@ contract ClaimReward_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test 
         assertEq(newPositionState.amountStaked, positionState.amountStaked);
         uint128 currentRewardPerToken;
         unchecked {
+            // forge-lint: disable-next-item(unsafe-typecast)
             currentRewardPerToken = assetState.lastRewardPerTokenGlobal
                 + uint128(assetState.currentRewardGlobal.mulDivDown(1e18, assetState.totalStaked));
         }

--- a/test/fuzz/asset-modules/AbstractStakingAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -30,6 +30,7 @@ contract GetUnderlyingAssetsAmounts_AbstractStakingAM_Fuzz_Test is AbstractStaki
         address underLyingAsset
     ) public {
         // And : pendingEmissions is smaller than type(uint128).max / 1e18
+        // forge-lint: disable-next-item(unsafe-typecast)
         pendingEmissions = uint128(bound(pendingEmissions, 0, type(uint128).max / 1e18));
 
         // And : Set valid state in AM

--- a/test/fuzz/asset-modules/AbstractStakingAM/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/IncreaseLiquidity.fuzz.t.sol
@@ -10,6 +10,7 @@ import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointM
 /**
  * @notice Fuzz tests for the function "increaseLiquidity" of contract "StakingAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IncreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/AbstractStakingAM/Mint.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/Mint.fuzz.t.sol
@@ -10,6 +10,7 @@ import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointM
 /**
  * @notice Fuzz tests for the function "mint" of contract "StakingAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/AbstractStakingAM/RewardOf.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/RewardOf.fuzz.t.sol
@@ -50,6 +50,7 @@ contract RewardOf_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
         uint256 deltaRewardGlobal = assetState.currentRewardGlobal;
         uint128 rewardPerToken;
         unchecked {
+            // forge-lint: disable-next-item(unsafe-typecast)
             rewardPerToken = assetState.lastRewardPerTokenGlobal
                 + uint128(deltaRewardGlobal.mulDivDown(1e18, assetState.totalStaked));
         }

--- a/test/fuzz/asset-modules/AbstractStakingAM/SetBaseURI.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/SetBaseURI.fuzz.t.sol
@@ -49,6 +49,7 @@ contract SetBaseURI_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
 
         string memory actualUri = stakingAM.tokenURI(id);
 
+        // forge-lint: disable-next-item(encode-packed-collision)
         assertEq(actualUri, string(abi.encodePacked(uri, id.toString())));
     }
 }

--- a/test/fuzz/asset-modules/AerodromePoolAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/AddAsset.fuzz.t.sol
@@ -10,6 +10,7 @@ import { AerodromePoolAM_Fuzz_Test } from "./_AerodromePoolAM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "AerodromePoolAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AerodromePoolAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -11,6 +11,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "AerodromePoolAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateValueAndRiskFactors_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AerodromePoolAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/GetRiskFactors.fuzz.t.sol
@@ -11,6 +11,7 @@ import { FixedPointMathLib } from "../../../../src/asset-modules/abstracts/Abstr
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "AerodromePoolAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetRiskFactors_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssets.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssets.fuzz.t.sol
@@ -9,6 +9,7 @@ import { AerodromePoolAM_Fuzz_Test } from "./_AerodromePoolAM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssets" of contract "AerodromePoolAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssets_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -12,6 +12,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "getUnderlyingAssetsAmounts" of contract "AerodromePoolAM".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     using stdStorage for StdStorage;

--- a/test/fuzz/asset-modules/AerodromePoolAM/_AerodromePoolAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/_AerodromePoolAM.fuzz.t.sol
@@ -15,6 +15,7 @@ import { Pool } from "../../../utils/mocks/Aerodrome/AeroPoolMock.sol";
 /**
  * @notice Common logic needed by "AerodromePoolAM" fuzz tests.
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 abstract contract AerodromePoolAM_Fuzz_Test is Fuzz_Test, AerodromeFixture {
     using FixedPointMathLib for uint256;
     /*////////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/AddAsset.fuzz.t.sol
@@ -11,6 +11,7 @@ import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "DefaultUniswapV4AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -11,6 +11,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "DefaultUniswapV4AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateValueAndRiskFactors_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetFeeAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetFeeAmounts.fuzz.t.sol
@@ -12,6 +12,7 @@ import { PositionInfo, PositionInfoLibrary } from "../../../../lib/v4-periphery/
 /**
  * @notice Fuzz tests for the function "_getFeeAmounts" of contract "DefaultUniswapV4AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetPrincipalAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetPrincipalAmounts.fuzz.t.sol
@@ -13,6 +13,7 @@ import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries
 /**
  * @notice Fuzz tests for the function "getPrincipalAmounts" of contract "DefaultUniswapV4AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetPrincipalAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssets.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssets.fuzz.t.sol
@@ -10,6 +10,7 @@ import { DefaultUniswapV4AM_Fuzz_Test } from "./_DefaultUniswapV4AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssets" of contract "DefaultUniswapV4AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssets_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -16,6 +16,7 @@ import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "DefaultUniswapV4AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
@@ -20,6 +20,7 @@ import { UniswapV4HooksRegistryExtension } from "../../../../test/utils/extensio
 /**
  * @notice Common logic needed by all "DefaultUniswapV4AM" fuzz tests.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
     /* ///////////////////////////////////////////////////////////////
                               CONSTANTS

--- a/test/fuzz/asset-modules/ERC20PrimaryAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/ERC20PrimaryAM/AddAsset.fuzz.t.sol
@@ -17,6 +17,7 @@ import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "ERC20PrimaryAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_ERC20PrimaryAM_Fuzz_Test is ERC20PrimaryAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/ERC20PrimaryAM/GetAssetFromKey.fuzz.t.sol
+++ b/test/fuzz/asset-modules/ERC20PrimaryAM/GetAssetFromKey.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetAssetFromKey_ERC20PrimaryAM_Fuzz_Test is ERC20PrimaryAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getAssetFromKey(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 key = bytes32(abi.encodePacked(assetId, asset));
         (address actualAsset, uint256 actualAssetId) = erc20AM.getAssetFromKey(key);
 

--- a/test/fuzz/asset-modules/ERC20PrimaryAM/GetKeyFromAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/ERC20PrimaryAM/GetKeyFromAsset.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetKeyFromAsset_ERC20PrimaryAM_Fuzz_Test is ERC20PrimaryAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getKeyFromAsset(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 expectedKey = bytes32(abi.encodePacked(uint96(0), asset));
         bytes32 actualKey = erc20AM.getKeyFromAsset(asset, assetId);
 

--- a/test/fuzz/asset-modules/ERC20PrimaryAM/_ERC20PrimaryAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/ERC20PrimaryAM/_ERC20PrimaryAM.fuzz.t.sol
@@ -28,6 +28,7 @@ abstract contract ERC20PrimaryAM_Fuzz_Test is Fuzz_Test {
         chainlinkOM.addOracle(address(mockOracles.token4ToUsd), "TOKEN4", "USD", 2 days);
 
         uint80[] memory oracleToken4ToUsdArr = new uint80[](1);
+        // forge-lint: disable-next-item(unsafe-typecast)
         oracleToken4ToUsdArr[0] = uint80(chainlinkOM.oracleToOracleId(address(mockOracles.token4ToUsd)));
         oraclesToken4ToUsd = BitPackingLib.pack(BA_TO_QA_SINGLE, oracleToken4ToUsdArr);
     }

--- a/test/fuzz/asset-modules/FloorERC1155AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/AddAsset.fuzz.t.sol
@@ -12,6 +12,7 @@ import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrima
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "FloorERC1155AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/FloorERC1155AM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/ProcessDirectDeposit.fuzz.t.sol
@@ -11,6 +11,7 @@ import { FloorERC1155AM_Fuzz_Test } from "./_FloorERC1155AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "processDirectDeposit" of contract "FloorERC1155AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ProcessDirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/FloorERC1155AM/_FloorERC1155AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/_FloorERC1155AM.fuzz.t.sol
@@ -28,6 +28,7 @@ abstract contract FloorERC1155AM_Fuzz_Test is Fuzz_Test {
         chainlinkOM.addOracle(address(mockOracles.sft2ToUsd), "SFT2", "USD", 2 days);
 
         uint80[] memory oracleSft2ToUsdArr = new uint80[](1);
+        // forge-lint: disable-next-item(unsafe-typecast)
         oracleSft2ToUsdArr[0] = uint80(chainlinkOM.oracleToOracleId(address(mockOracles.sft2ToUsd)));
         oraclesSft2ToUsd = BitPackingLib.pack(BA_TO_QA_SINGLE, oracleSft2ToUsdArr);
     }

--- a/test/fuzz/asset-modules/FloorERC721AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/AddAsset.fuzz.t.sol
@@ -14,6 +14,7 @@ import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "FloorERC721AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_FloorERC721AM_Fuzz_Test is FloorERC721AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/FloorERC721AM/GetAssetFromKey.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/GetAssetFromKey.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetAssetFromKey_FloorERC721AM_Fuzz_Test is FloorERC721AM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getAssetFromKey(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 key = bytes32(abi.encodePacked(assetId, asset));
         (address actualAsset, uint256 actualAssetId) = floorERC721AM.getAssetFromKey(key);
 

--- a/test/fuzz/asset-modules/FloorERC721AM/GetKeyFromAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/GetKeyFromAsset.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetKeyFromAsset_FloorERC721AM_Fuzz_Test is FloorERC721AM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getKeyFromAsset(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 expectedKey = bytes32(abi.encodePacked(uint96(0), asset));
         bytes32 actualKey = floorERC721AM.getKeyFromAsset(asset, assetId);
 

--- a/test/fuzz/asset-modules/FloorERC721AM/_FloorERC721AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/_FloorERC721AM.fuzz.t.sol
@@ -29,6 +29,7 @@ abstract contract FloorERC721AM_Fuzz_Test is Fuzz_Test {
         chainlinkOM.addOracle(address(mockOracles.nft2ToUsd), "NFT2", "USD", 2 days);
 
         uint80[] memory oracleNft2ToUsdArr = new uint80[](1);
+        // forge-lint: disable-next-item(unsafe-typecast)
         oracleNft2ToUsdArr[0] = uint80(chainlinkOM.oracleToOracleId(address(mockOracles.nft2ToUsd)));
         oraclesNft2ToUsd = BitPackingLib.pack(BA_TO_QA_SINGLE, oracleNft2ToUsdArr);
     }

--- a/test/fuzz/asset-modules/NativeTokenAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/NativeTokenAM/AddAsset.fuzz.t.sol
@@ -12,6 +12,7 @@ import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "NativeTokenAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_NativeTokenAM_Fuzz_Test is NativeTokenAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/NativeTokenAM/GetAssetFromKey.fuzz.t.sol
+++ b/test/fuzz/asset-modules/NativeTokenAM/GetAssetFromKey.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetAssetFromKey_NativeTokenAM_Fuzz_Test is NativeTokenAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getAssetFromKey(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 key = bytes32(abi.encodePacked(assetId, asset));
         (address actualAsset, uint256 actualAssetId) = nativeTokenAM.getAssetFromKey(key);
 

--- a/test/fuzz/asset-modules/NativeTokenAM/GetKeyFromAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/NativeTokenAM/GetKeyFromAsset.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetKeyFromAsset_NativeTokenAM_Fuzz_Test is NativeTokenAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getKeyFromAsset(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 expectedKey = bytes32(abi.encodePacked(uint96(0), asset));
         bytes32 actualKey = nativeTokenAM.getKeyFromAsset(asset, assetId);
 

--- a/test/fuzz/asset-modules/SlipstreamAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/AddAsset.fuzz.t.sol
@@ -12,6 +12,7 @@ import { SlipstreamAM } from "../../../../src/asset-modules/Slipstream/Slipstrea
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "SlipstreamAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/SlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "SlipstreamAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateValueAndRiskFactors_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/SlipstreamAM/GetPosition.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetPosition.fuzz.t.sol
@@ -46,6 +46,7 @@ contract GetPosition_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         position = givenValidPosition(position);
 
         // And: Liquidity is non-zero.
+        // forge-lint: disable-next-item(unsafe-typecast)
         position.liquidity = uint128(bound(position.liquidity, 1, type(uint128).max));
 
         // And: State is persisted.

--- a/test/fuzz/asset-modules/SlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -15,6 +15,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "SlipstreamAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssetsAmounts_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
@@ -125,6 +125,7 @@ abstract contract SlipstreamAM_Fuzz_Test is Fuzz_Test, SlipstreamFixture {
         returns (NonfungiblePositionManagerMock.Position memory)
     {
         // Given: poolId is non zero (=position is initialised).
+        // forge-lint: disable-next-item(unsafe-typecast)
         position.poolId = uint80(bound(position.poolId, 1, type(uint80).max));
 
         // And: Ticks are within allowed ranges.

--- a/test/fuzz/asset-modules/StakedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
@@ -10,6 +10,7 @@ import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointM
 /**
  * @notice Fuzz tests for the function "increaseLiquidity" of contract "StakedAerodromeAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IncreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/StakedAerodromeAM/Mint.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/Mint.fuzz.t.sol
@@ -15,6 +15,7 @@ import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointM
 /**
  * @notice Fuzz tests for the function "mint" of contract "StakedAerodromeAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/StakedAerodromeAM/_StakedAerodromeAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/_StakedAerodromeAM.fuzz.t.sol
@@ -43,6 +43,7 @@ abstract contract StakedAerodromeAM_Fuzz_Test is Fuzz_Test, AbstractStakingAM_Fu
         rewardToken = ERC20Mock(AERO);
 
         // Add the reward token to the Registry
+        // forge-lint: disable-next-item(unsafe-typecast)
         addAssetToArcadia(AERO, int256(rates.token1ToUsd));
 
         // Deploy Aerodrome AM.

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/Burn.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/Burn.fuzz.t.sol
@@ -72,6 +72,7 @@ contract Burn_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz_Test {
         position = givenValidPosition(position, 1);
 
         // And : the current tick of the pool is in range (can't be equal to tickUpper, but can be equal to tickLower).
+        // forge-lint: disable-next-item(unsafe-typecast)
         tick = int24(bound(tick, position.tickLower, position.tickUpper - 1));
         deployAndAddGauge(tick);
 

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "StakedSlipstreamAM".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract CalculateValueAndRiskFactors_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/ClaimReward.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/ClaimReward.fuzz.t.sol
@@ -15,6 +15,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "claimReward" of contract "StakedSlipstreamAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ClaimReward_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -73,6 +74,7 @@ contract ClaimReward_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz_Tes
         position = givenValidPosition(position, 1);
 
         // And : the current tick of the pool is in range (can't be equal to tickUpper, but can be equal to tickLower).
+        // forge-lint: disable-next-item(unsafe-typecast)
         tick = int24(bound(tick, position.tickLower, position.tickUpper - 1));
         deployAndAddGauge(tick);
 
@@ -111,7 +113,7 @@ contract ClaimReward_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz_Tes
         // Then : correct event is emitted.
         vm.prank(users.liquidityProvider);
         vm.expectEmit();
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit StakedSlipstreamAM.RewardPaid(assetId, AERO, uint128(rewardsExpected));
         uint256 rewards = stakedSlipstreamAM.claimReward(assetId);
 

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/RewardOf.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/RewardOf.fuzz.t.sol
@@ -15,6 +15,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Fuzz tests for the function "rewardOf" of contract "StakedSlipstreamAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract RewardOf_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/SetBaseURI.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/SetBaseURI.fuzz.t.sol
@@ -51,6 +51,7 @@ contract SetBaseURI_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz_Test
 
         string memory actualUri = stakedSlipstreamAM.tokenURI(id);
 
+        // forge-lint: disable-next-item(encode-packed-collision)
         assertEq(actualUri, string(abi.encodePacked(uri, id.toString())));
     }
 }

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/_StakedSlipstreamAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/_StakedSlipstreamAM.fuzz.t.sol
@@ -20,6 +20,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Common logic needed by all "StakedSlipstreamAM" fuzz tests.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 abstract contract StakedSlipstreamAM_Fuzz_Test is Fuzz_Test, SlipstreamFixture {
     /* ///////////////////////////////////////////////////////////////
                               VARIABLES

--- a/test/fuzz/asset-modules/StakedStargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "StakedStargateAM".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract CalculateValueAndRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "StakedStargateAM".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StakedStargateAM/_StakedStargateAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/_StakedStargateAM.fuzz.t.sol
@@ -48,6 +48,7 @@ abstract contract StakedStargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
         vm.startPrank(users.owner);
         chainlinkOM.addOracle(address(stargateOracle), "STG", "USD", 2 days);
         uint80[] memory oracleStgToUsdArr = new uint80[](1);
+        // forge-lint: disable-next-item(unsafe-typecast)
         oracleStgToUsdArr[0] = uint80(chainlinkOM.oracleToOracleId(address(stargateOracle)));
         erc20AM.addAsset(address(lpStakingTimeMock.eToken()), BitPackingLib.pack(BA_TO_QA_SINGLE, oracleStgToUsdArr));
 

--- a/test/fuzz/asset-modules/StandardERC4626AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/AddAsset.fuzz.t.sol
@@ -12,6 +12,7 @@ import { StandardERC4626AM_Fuzz_Test } from "./_StandardERC4626AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "StandardERC4626AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_StandardERC4626AM_Fuzz_Test is StandardERC4626AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StandardERC4626AM/GetAssetFromKey.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/GetAssetFromKey.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetAssetFromKey_StandardERC4626AM_Fuzz_Test is StandardERC4626AM_Fuzz_T
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getAssetFromKey(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 key = bytes32(abi.encodePacked(assetId, asset));
         (address actualAsset, uint256 actualAssetId) = erc4626AM.getAssetFromKey(key);
 

--- a/test/fuzz/asset-modules/StandardERC4626AM/GetKeyFromAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/GetKeyFromAsset.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetKeyFromAsset_StandardERC4626AM_Fuzz_Test is StandardERC4626AM_Fuzz_T
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getKeyFromAsset(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 expectedKey = bytes32(abi.encodePacked(uint96(0), asset));
         bytes32 actualKey = erc4626AM.getKeyFromAsset(asset, assetId);
 

--- a/test/fuzz/asset-modules/StandardERC4626AM/GetUnderlyingAssets.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/GetUnderlyingAssets.fuzz.t.sol
@@ -9,6 +9,7 @@ import { StandardERC4626AM_Fuzz_Test } from "./_StandardERC4626AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssets" of contract "StandardERC4626AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssets_StandardERC4626AM_Fuzz_Test is StandardERC4626AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StandardERC4626AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -48,6 +48,7 @@ contract GetUnderlyingAssetsAmounts_StandardERC4626AM_Fuzz_Test is StandardERC46
             .checked_write(totalAssets);
 
         // When: "_getUnderlyingAssetsAmounts" is called with 'shares'.
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(ybToken1)));
         bytes32[] memory emptyArray = new bytes32[](1);
         (uint256[] memory underlyingAssetsAmounts, AssetValueAndRiskFactors[] memory rateUnderlyingAssetsToUsd) =

--- a/test/fuzz/asset-modules/StargateAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/AddAsset.fuzz.t.sol
@@ -10,6 +10,7 @@ import { StargateAM } from "../../../../src/asset-modules/Stargate-Finance/Starg
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "StargateAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -10,6 +10,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "StargateAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateValueAndRiskFactors_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StargateAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/GetRiskFactors.fuzz.t.sol
@@ -10,6 +10,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "StargateAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetRiskFactors_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StargateAM/GetUnderlyingAssets.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/GetUnderlyingAssets.fuzz.t.sol
@@ -9,6 +9,7 @@ import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssets" of contract "StargateAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssets_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/StargateAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -10,6 +10,7 @@ import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuati
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "StargateAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssetsAmounts_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -58,6 +59,7 @@ contract GetUnderlyingAssetsAmounts_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test
 
         // Then : Asset amounts returned should be correct.
         uint256 computedUnderlyingAssetAmount = uint256(assetAmount) * totalLiquidity / totalSupply;
+        // forge-lint: disable-next-item(divide-before-multiply)
         computedUnderlyingAssetAmount *= convertRate;
         assertEq(underlyingAssetsAmounts[0], computedUnderlyingAssetAmount);
 

--- a/test/fuzz/asset-modules/UniswapV2AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/AddAsset.fuzz.t.sol
@@ -13,6 +13,7 @@ import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "UniswapV2AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/UniswapV2AM/GetAssetFromKey.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetAssetFromKey.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetAssetFromKey_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getAssetFromKey(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 key = bytes32(abi.encodePacked(assetId, asset));
         (address actualAsset, uint256 actualAssetId) = uniswapV2AM.getAssetFromKey(key);
 

--- a/test/fuzz/asset-modules/UniswapV2AM/GetKeyFromAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetKeyFromAsset.fuzz.t.sol
@@ -22,6 +22,7 @@ contract GetKeyFromAsset_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getKeyFromAsset(address asset, uint96 assetId) public view {
+        // forge-lint: disable-next-item(unsafe-typecast)
         bytes32 expectedKey = bytes32(abi.encodePacked(uint96(0), asset));
         bytes32 actualKey = uniswapV2AM.getKeyFromAsset(asset, assetId);
 

--- a/test/fuzz/asset-modules/UniswapV2AM/GetUnderlyingAssets.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetUnderlyingAssets.fuzz.t.sol
@@ -9,6 +9,7 @@ import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssets" of contract "UniswapV2AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssets_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/UniswapV2AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetValue.fuzz.t.sol
@@ -12,6 +12,7 @@ import { UniswapV2PairMock } from "../../../utils/mocks/UniswapV2/UniswapV2PairM
 /**
  * @notice Fuzz tests for the function "getValue" of contract "UniswapV2AM".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract GetValue_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/UniswapV2AM/_UniswapV2AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/_UniswapV2AM.fuzz.t.sol
@@ -93,6 +93,7 @@ abstract contract UniswapV2AM_Fuzz_Test is Fuzz_Test {
         oracleTokenToUsd = initMockedOracle(oracleTokenToUsdDecimals, string(abi.encodePacked(label, " / USD")), rate);
 
         vm.startPrank(users.owner);
+        // forge-lint: disable-next-item(unsafe-typecast)
         uint80 oracleId = uint80(chainlinkOM.addOracle(address(oracleTokenToUsd), "Mock", "USD", 2 days));
         uint80[] memory oracleTokenToUsdArr = new uint80[](1);
         oracleTokenToUsdArr[0] = oracleId;

--- a/test/fuzz/asset-modules/UniswapV3AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/AddAsset.fuzz.t.sol
@@ -11,6 +11,7 @@ import { UniswapV3AM } from "../../../../src/asset-modules/UniswapV3/UniswapV3AM
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "UniswapV3AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/UniswapV3AM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "UniswapV3AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateValueAndRiskFactors_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/UniswapV3AM/GetPosition.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetPosition.fuzz.t.sol
@@ -46,6 +46,7 @@ contract GetPosition_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         position = givenValidPosition(position);
 
         // And: Liquidity is non-zero.
+        // forge-lint: disable-next-item(unsafe-typecast)
         position.liquidity = uint128(bound(position.liquidity, 1, type(uint128).max));
 
         // And: State is persisted.

--- a/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -18,6 +18,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "UniswapV3AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUnderlyingAssetsAmounts_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
@@ -109,6 +109,7 @@ abstract contract UniswapV3AM_Fuzz_Test is Fuzz_Test, UniswapV3Fixture, UniswapV
         returns (NonfungiblePositionManagerMock.Position memory)
     {
         // Given: poolId is non zero (=position is initialised).
+        // forge-lint: disable-next-item(unsafe-typecast)
         position.poolId = uint80(bound(position.poolId, 1, type(uint80).max));
 
         // And: Ticks are within allowed ranges.

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetValuesInUsdRecursive.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetValuesInUsdRecursive.fuzz.t.sol
@@ -11,6 +11,7 @@ import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz
 /**
  * @notice Fuzz tests for the function "getValuesInUsdRecursive" of contract "UniswapV4HooksRegistry".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetValuesInUsdRecursive_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                              VARIABLES

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/SetProtocol.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/SetProtocol.fuzz.t.sol
@@ -64,6 +64,7 @@ contract SetProtocol_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_
             IPositionDescriptor(address(0)),
             IWETH9(address(weth9))
         );
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode = abi.encodePacked(vm.getCode("PositionManagerExtension.sol"), args);
         address positionManagerV4_ = Utils.deployBytecode(bytecode);
 

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/SetRiskParametersOfDerivedAssetModule.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/SetRiskParametersOfDerivedAssetModule.fuzz.t.sol
@@ -52,6 +52,7 @@ contract SetRiskParametersOfDerivedAM_UniswapV4HooksRegistry_Fuzz_Test is Uniswa
     }
 
     function testFuzz_Success_setRiskParametersOfDerivedAM(uint112 maxUsdExposureProtocol, uint16 riskFactor) public {
+        // forge-lint: disable-next-item(unsafe-typecast)
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
 
         vm.prank(users.riskManager);

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "WrappedAerodromeAM".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract CalculateValueAndRiskFactors_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/FeesOf.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/FeesOf.fuzz.t.sol
@@ -11,6 +11,7 @@ import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Fina
 /**
  * @notice Fuzz tests for the function "feesOf" of contract "WrappedAerodromeAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract FeesOf_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
 

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/GetCurrentFees.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/GetCurrentFees.fuzz.t.sol
@@ -10,6 +10,7 @@ import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Fina
 /**
  * @notice Fuzz tests for the function "_getCurrentFees" of contract "WrappedAerodromeAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetCurrentFees_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
@@ -13,6 +13,7 @@ import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Fina
 /**
  * @notice Fuzz tests for the function "increaseLiquidity" of contract "WrappedAerodromeAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IncreaseLiquidity_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/Mint.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/Mint.fuzz.t.sol
@@ -13,6 +13,7 @@ import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Fina
 /**
  * @notice Fuzz tests for the function "mint" of contract "WrappedAerodromeAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/SetBaseURI.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/SetBaseURI.fuzz.t.sol
@@ -49,6 +49,7 @@ contract SetBaseURI_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test
 
         string memory actualUri = wrappedAerodromeAM.tokenURI(id);
 
+        // forge-lint: disable-next-item(encode-packed-collision)
         assertEq(actualUri, string(abi.encodePacked(uri, id.toString())));
     }
 }

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/Skim.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/Skim.fuzz.t.sol
@@ -13,6 +13,7 @@ import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Fina
 /**
  * @notice Fuzz tests for the function "skim" of contract "WrappedAerodromeAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Skim_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
 

--- a/test/fuzz/oracle-modules/AbstractOM/Constructor.fuzz.t.sol
+++ b/test/fuzz/oracle-modules/AbstractOM/Constructor.fuzz.t.sol
@@ -16,6 +16,7 @@ contract Constructor_AbstractOM_Fuzz_Test is AbstractOM_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/oracle-modules/ChainlinkOM/AddOracle.fuzz.t.sol
+++ b/test/fuzz/oracle-modules/ChainlinkOM/AddOracle.fuzz.t.sol
@@ -13,6 +13,7 @@ import { OracleModule } from "../../../../src/oracle-modules/abstracts/AbstractO
 /**
  * @notice Fuzz tests for the function "addOracle" of contract "ChainlinkOM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddOracle_ChainlinkOM_Fuzz_Test is ChainlinkOM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/oracle-modules/ChainlinkOM/Constructor.fuzz.t.sol
+++ b/test/fuzz/oracle-modules/ChainlinkOM/Constructor.fuzz.t.sol
@@ -16,6 +16,7 @@ contract Constructor_ChainlinkOM_Fuzz_Test is ChainlinkOM_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/oracle-modules/ChainlinkOM/IsActive.fuzz.t.sol
+++ b/test/fuzz/oracle-modules/ChainlinkOM/IsActive.fuzz.t.sol
@@ -11,6 +11,7 @@ import { RevertingOracle } from "../../../utils/mocks/oracles/RevertingOracle.so
 /**
  * @notice Fuzz tests for the function "isActive" of contract "ChainlinkOM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IsActive_ChainlinkOM_Fuzz_Test is ChainlinkOM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL1/BatchProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/BatchProcessDeposit.fuzz.t.sol
@@ -9,10 +9,12 @@ import { RegistryL1_Fuzz_Test } from "./_RegistryL1.fuzz.t.sol";
 import { AssetModule } from "../../../../src/asset-modules/abstracts/AbstractAM.sol";
 import { GuardianErrors } from "../../../../src/libraries/Errors.sol";
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
+
 /**
  * @notice Fuzz tests for the function "batchProcessDeposit" of contract "RegistryL1".
  */
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BatchProcessDeposit_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL1/BatchProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/BatchProcessWithdrawal.fuzz.t.sol
@@ -13,6 +13,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "batchProcessWithdrawal" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BatchProcessWithdrawal_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/registries/RegistryL1/GetCollateralValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetCollateralValue.fuzz.t.sol
@@ -12,6 +12,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getCollateralValue" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetCollateralValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL1/GetLiquidationValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetLiquidationValue.fuzz.t.sol
@@ -51,6 +51,7 @@ contract GetLiquidationValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         uint32 currentTime
     ) public {
         // Given: oracle staleness-check does not underflow.
+        // forge-lint: disable-next-item(unsafe-typecast)
         currentTime = uint32(bound(currentTime, 2 days, type(uint32).max));
         vm.warp(currentTime);
 

--- a/test/fuzz/registries/RegistryL1/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetRiskFactors_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL1/GetValuesInNumeraire.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetValuesInNumeraire.fuzz.t.sol
@@ -13,6 +13,7 @@ import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuati
 /**
  * @notice Fuzz tests for the function "getValuesInNumeraire" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetValuesInNumeraire_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL1/GetValuesInUsd.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetValuesInUsd.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
 /**
  * @notice Fuzz tests for the function "getValuesInUsd" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetValuesInUsd_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL1/GetValuesInUsdRecursive.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetValuesInUsdRecursive.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
 /**
  * @notice Fuzz tests for the function "getValuesInUsdRecursive" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetValuesInUsdRecursive_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL1/SetRiskParametersOfDerivedAssetModule.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/SetRiskParametersOfDerivedAssetModule.fuzz.t.sol
@@ -40,6 +40,7 @@ contract SetRiskParametersOfDerivedAM_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Te
     }
 
     function testFuzz_Success_setRiskParametersOfDerivedAM(uint112 maxUsdExposureProtocol, uint16 riskFactor) public {
+        // forge-lint: disable-next-item(unsafe-typecast)
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
 
         vm.prank(users.riskManager);

--- a/test/fuzz/registries/RegistryL1/SetRiskParametersOfPrimaryAsset.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/SetRiskParametersOfPrimaryAsset.fuzz.t.sol
@@ -13,6 +13,7 @@ import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrima
 /**
  * @notice Fuzz tests for the function "setRiskParametersOfPrimaryAsset" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetRiskParametersOfPrimaryAsset_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/BatchProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/BatchProcessDeposit.fuzz.t.sol
@@ -9,10 +9,12 @@ import { RegistryL2_Fuzz_Test } from "./_RegistryL2.fuzz.t.sol";
 import { AssetModule } from "../../../../src/asset-modules/abstracts/AbstractAM.sol";
 import { GuardianErrors } from "../../../../src/libraries/Errors.sol";
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
+
 /**
  * @notice Fuzz tests for the function "batchProcessDeposit" of contract "RegistryL2".
  */
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BatchProcessDeposit_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/BatchProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/BatchProcessWithdrawal.fuzz.t.sol
@@ -13,6 +13,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "batchProcessWithdrawal" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BatchProcessWithdrawal_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/registries/RegistryL2/GetCollateralValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetCollateralValue.fuzz.t.sol
@@ -13,6 +13,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getCollateralValue" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetCollateralValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/GetLiquidationValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetLiquidationValue.fuzz.t.sol
@@ -13,6 +13,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getLiquidationValue" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetLiquidationValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetRiskFactors.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetRiskFactors_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/GetValuesInNumeraire.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetValuesInNumeraire.fuzz.t.sol
@@ -13,6 +13,7 @@ import { RegistryL2_Fuzz_Test } from "./_RegistryL2.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "getValuesInNumeraire" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetValuesInNumeraire_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/GetValuesInUsd.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetValuesInUsd.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
 /**
  * @notice Fuzz tests for the function "getValuesInUsd" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetValuesInUsd_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/GetValuesInUsdRecursive.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetValuesInUsdRecursive.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
 /**
  * @notice Fuzz tests for the function "getValuesInUsdRecursive" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetValuesInUsdRecursive_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/IsSequencerDown.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/IsSequencerDown.fuzz.t.sol
@@ -9,6 +9,7 @@ import { RegistryL2_Fuzz_Test } from "./_RegistryL2.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_isSequencerDown" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IsSequencerDown_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/registries/RegistryL2/SetRiskParametersOfDerivedAssetModule.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/SetRiskParametersOfDerivedAssetModule.fuzz.t.sol
@@ -40,6 +40,7 @@ contract SetRiskParametersOfDerivedAM_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Te
     }
 
     function testFuzz_Success_setRiskParametersOfDerivedAM(uint112 maxUsdExposureProtocol, uint16 riskFactor) public {
+        // forge-lint: disable-next-item(unsafe-typecast)
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
 
         vm.prank(users.riskManager);

--- a/test/fuzz/registries/RegistryL2/SetRiskParametersOfPrimaryAsset.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/SetRiskParametersOfPrimaryAsset.fuzz.t.sol
@@ -13,6 +13,7 @@ import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrima
 /**
  * @notice Fuzz tests for the function "setRiskParametersOfPrimaryAsset" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetRiskParametersOfPrimaryAsset_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/utils/extensions/BaseGuardianExtension.sol
+++ b/test/utils/extensions/BaseGuardianExtension.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.0;
 
 import { BaseGuardian } from "../../../src/guardians/BaseGuardian.sol";
 
+// forge-lint: disable-next-item(empty-block)
 contract BaseGuardianExtension is BaseGuardian {
     constructor(address owner_) BaseGuardian(owner_) { }
 

--- a/test/utils/fixtures/aerodrome/AerodromeFixture.f.sol
+++ b/test/utils/fixtures/aerodrome/AerodromeFixture.f.sol
@@ -53,6 +53,7 @@ contract AerodromeFixture is Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     function createPoolAerodrome(address token0, address token1, bool stable) internal returns (Pool pool) {
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         pool = Pool(aeroPoolFactory.createPool(token0, token1, stable));
     }
 

--- a/test/utils/fixtures/arcadia-accounts/ArcadiaAccountsFixture.f.sol
+++ b/test/utils/fixtures/arcadia-accounts/ArcadiaAccountsFixture.f.sol
@@ -20,6 +20,7 @@ import { FactoryExtension } from "../../extensions/FactoryExtension.sol";
 import { RegistryL2Extension } from "../../extensions/RegistryL2Extension.sol";
 import { SequencerUptimeOracle } from "../../mocks/oracles/SequencerUptimeOracle.sol";
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ArcadiaAccountsFixture is Base_Test {
     function deployArcadiaAccounts(address merklDistributor) public {
         // Deploy the sequencer uptime oracle.

--- a/test/utils/fixtures/arcadia-accounts/UniswapV3AMFixture.f.sol
+++ b/test/utils/fixtures/arcadia-accounts/UniswapV3AMFixture.f.sol
@@ -9,6 +9,7 @@ import { Constants } from "../../../utils/Constants.sol";
 import { UniswapV3AMExtension } from "../../extensions/UniswapV3AMExtension.sol";
 import { Utils } from "../../Utils.sol";
 
+// forge-lint: disable-next-item(encode-packed-collision)
 contract UniswapV3AMFixture is Base_Test {
     /*//////////////////////////////////////////////////////////////////////////
                                      VARIABLES

--- a/test/utils/fixtures/slipstream/CLQuoter.f.sol
+++ b/test/utils/fixtures/slipstream/CLQuoter.f.sol
@@ -23,6 +23,7 @@ contract CLQuoterFixture is Test {
     function deployQuoter(address factory_, address weth9_) public {
         // Get the bytecode of the Quoter.
         bytes memory args = abi.encode(factory_, weth9_);
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode = abi.encodePacked(vm.getCode("CLQuoterV2Extension.sol"), args);
 
         address quoter_ = Utils.deployBytecode(bytecode);

--- a/test/utils/fixtures/slipstream/CLSwapRouter.f.sol
+++ b/test/utils/fixtures/slipstream/CLSwapRouter.f.sol
@@ -23,6 +23,7 @@ contract CLSwapRouterFixture is Test {
     function deploySwapRouter(address factory_, address weth9_) public {
         // Get the bytecode of the SwapRouterExtension.
         bytes memory args = abi.encode(factory_, weth9_);
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode = abi.encodePacked(vm.getCode("SwapRouter.sol"), args);
 
         address swapRouter_ = Utils.deployBytecode(bytecode);

--- a/test/utils/fixtures/slipstream/Slipstream.f.sol
+++ b/test/utils/fixtures/slipstream/Slipstream.f.sol
@@ -19,7 +19,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 import { Utils } from "../../Utils.sol";
 import { WETH9Fixture } from "../weth9/WETH9Fixture.f.sol";
 
-// forge-lint: disable-next-item(divide-before-multiply,mixed-case-function)
+// forge-lint: disable-next-item(divide-before-multiply,encode-packed-collision,mixed-case-function)
 contract SlipstreamFixture is WETH9Fixture, AerodromeFixture {
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS

--- a/test/utils/fixtures/swap-router-02/SwapRouter02Fixture.f.sol
+++ b/test/utils/fixtures/swap-router-02/SwapRouter02Fixture.f.sol
@@ -9,6 +9,7 @@ import { ISwapRouter02 } from "./interfaces/ISwapRouter02.sol";
 import { Test } from "../../../../lib/forge-std/src/Test.sol";
 import { Utils } from "../../../utils/Utils.sol";
 
+// forge-lint: disable-next-item(encode-packed-collision)
 contract SwapRouter02Fixture is Test {
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS

--- a/test/utils/fixtures/uniswap-v3/QuoterV2Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v3/QuoterV2Fixture.f.sol
@@ -9,6 +9,7 @@ import { IQuoterV2 } from "./extensions/interfaces/IQuoterV2.sol";
 import { Test } from "../../../../lib/forge-std/src/Test.sol";
 import { Utils } from "../../../utils/Utils.sol";
 
+// forge-lint: disable-next-item(encode-packed-collision)
 contract QuoterV2Fixture is Test {
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS

--- a/test/utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol
@@ -48,6 +48,7 @@ contract UniswapV3Fixture is WETH9Fixture {
 
         // Get the bytecode of the UniswapV3PoolExtension.
         args = abi.encode();
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode = abi.encodePacked(vm.getCode("UniswapV3PoolExtension.sol"), args);
         bytes32 poolExtensionInitCodeHash = keccak256(bytecode);
 

--- a/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
@@ -281,6 +281,7 @@ contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
         approveV4PositionManagerFor(liquidityProvider, token1);
 
         vm.prank(liquidityProvider);
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         positionManagerV4.modifyLiquidities{ value: token0 == address(0) ? amount0 + 1 : 0 }(mintData, block.timestamp);
     }
 

--- a/test/utils/mocks/Aerodrome/AeroPoolFactoryMock.sol
+++ b/test/utils/mocks/Aerodrome/AeroPoolFactoryMock.sol
@@ -152,6 +152,7 @@ contract PoolFactory {
         if (_getPool[token0][token1][stable] != address(0)) revert PoolAlreadyExists();
         bytes32 salt = keccak256(abi.encodePacked(token0, token1, stable)); // salt includes stable as well, 3 parameters
         pool = Clones.cloneDeterministic(implementation, salt);
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IPool(pool).initialize(token0, token1, stable);
         _getPool[token0][token1][stable] = pool;
         _getPool[token1][token0][stable] = pool; // populate mapping in the reverse direction

--- a/test/utils/mocks/Aerodrome/VoterMock.sol
+++ b/test/utils/mocks/Aerodrome/VoterMock.sol
@@ -4,6 +4,7 @@
  */
 pragma solidity ^0.8.0;
 
+// forge-lint: disable-next-item(uninitialized-state)
 contract VoterMock {
     address public factoryRegistry;
     address public ve;

--- a/test/utils/mocks/UniswapV2/UniswapV2FactoryMock.sol
+++ b/test/utils/mocks/UniswapV2/UniswapV2FactoryMock.sol
@@ -40,6 +40,7 @@ contract UniswapV2FactoryMock {
         assembly {
             pair := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IUniswapV2PairExtension(pair).initialize(token0, token1);
         getPair[token0][token1] = pair;
         getPair[token1][token0] = pair; // populate mapping in the reverse direction

--- a/test/utils/mocks/UniswapV2/UniswapV2PairMock.sol
+++ b/test/utils/mocks/UniswapV2/UniswapV2PairMock.sol
@@ -8,7 +8,7 @@ import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
 import { IUniswapV2Factory } from "./../asset-modules/interfaces/IUniswapV2Factory.sol";
 
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(unsafe-typecast,weak-prng)
 contract UniswapV2PairMock is ERC20 {
     uint256 public constant MINIMUM_LIQUIDITY = 10 ** 3;
 

--- a/test/utils/mocks/accounts/AccountLogicMock.sol
+++ b/test/utils/mocks/accounts/AccountLogicMock.sol
@@ -29,6 +29,7 @@ import { IPermit2 } from "../../../../src/interfaces/IPermit2.sol";
  * Arcadia's Account functions will guarantee you a certain value of the Account.
  * For whitelists or liquidation strategies specific to your protocol, contact: dev at arcadia.finance
  */
+// forge-lint: disable-next-item(arbitrary-send-erc20,reentrancy-no-eth,solmate-safe-transfer-lib)
 contract AccountLogicMock is AccountStorageV2 {
     using SafeTransferLib for ERC20;
 

--- a/test/utils/mocks/accounts/AccountStorageV2.sol
+++ b/test/utils/mocks/accounts/AccountStorageV2.sol
@@ -11,5 +11,6 @@ contract AccountStorageV2 is AccountStorageV1 {
                                 STORAGE
     ////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(uninitialized-state)
     uint256 public storageV2;
 }

--- a/test/utils/mocks/asset-managers/AssetManagerMock.sol
+++ b/test/utils/mocks/asset-managers/AssetManagerMock.sol
@@ -5,5 +5,6 @@
 pragma solidity ^0.8.0;
 
 contract AssetManagerMock {
+    // forge-lint: disable-next-item(empty-block)
     function onSetAssetManager(address accountOwner, bool operatorStatus, bytes calldata operatorData) external { }
 }

--- a/test/utils/mocks/asset-modules/AssetModuleMock.sol
+++ b/test/utils/mocks/asset-modules/AssetModuleMock.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import { AssetModuleExtension } from "../../extensions/AssetModuleExtension.sol";
 
+// forge-lint: disable-next-item(empty-block)
 contract AssetModuleMock is AssetModuleExtension {
     constructor(address owner_, address registry_, uint256 assetType_)
         AssetModuleExtension(owner_, registry_, assetType_)

--- a/test/utils/mocks/asset-modules/DerivedAMMock.sol
+++ b/test/utils/mocks/asset-modules/DerivedAMMock.sol
@@ -6,6 +6,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
 import { IRegistry } from "../../../../src/asset-modules/interfaces/IRegistry.sol";
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract DerivedAMMock is DerivedAMExtension {
     using FixedPointMathLib for uint256;
 
@@ -19,6 +20,7 @@ contract DerivedAMMock is DerivedAMExtension {
         DerivedAMExtension(owner_, registry_, assetType_)
     { }
 
+    // forge-lint: disable-next-item(empty-block)
     function isAllowed(address asset, uint256) public view override returns (bool) { }
 
     function setUnderlyingAssetsAmount(uint256 underlyingAssetAmount_) public {

--- a/test/utils/mocks/asset-modules/FloorERC1155AM.sol
+++ b/test/utils/mocks/asset-modules/FloorERC1155AM.sol
@@ -14,6 +14,7 @@ import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrima
  *  for which a direct price feed exists per Id.
  * @dev No end-user should directly interact with the FloorERC1155AM, only the Registry or the contract owner
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract FloorERC1155AM is PrimaryAM {
     /* //////////////////////////////////////////////////////////////
                                 ERRORS
@@ -51,7 +52,7 @@ contract FloorERC1155AM is PrimaryAM {
             if (assetToInformation[_getKeyFromAsset(asset, assetId)].assetUnit != 0) revert AssetAlreadyInAM();
         } else {
             // New contract address.
-            // forge-lint: disable-next-line(unsafe-typecast)
+            // forge-lint: disable-next-item(reentrancy-no-eth,unsafe-typecast)
             IRegistry(REGISTRY).addAsset(uint96(ASSET_TYPE), asset);
             inAssetModule[asset] = true;
         }

--- a/test/utils/mocks/asset-modules/StandardERC4626AM.sol
+++ b/test/utils/mocks/asset-modules/StandardERC4626AM.sol
@@ -14,6 +14,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
  * @notice The StandardERC4626Registry stores pricing logic and basic information for ERC4626 tokens for which the underlying assets have direct price feed.
  * @dev No end-user should directly interact with the StandardERC4626Registry, only the Registry or the contract owner
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract StandardERC4626AM is DerivedAM {
     using FixedPointMathLib for uint256;
     /* //////////////////////////////////////////////////////////////

--- a/test/utils/mocks/asset-modules/UniswapV2AM.sol
+++ b/test/utils/mocks/asset-modules/UniswapV2AM.sol
@@ -18,6 +18,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/lib
  * @dev Most logic in this contract is a modifications of
  *      https://github.com/Uniswap/v2-periphery/blob/master/contracts/libraries/UniswapV2LiquidityMathLibrary.sol#L23
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract UniswapV2AM is DerivedAM {
     using FixedPointMathLib for uint256;
     /* //////////////////////////////////////////////////////////////
@@ -333,6 +334,7 @@ contract UniswapV2AM is DerivedAM {
         );
         uint256 rightSide = (token0ToToken1 ? reserve0 * 1000 : reserve1 * 1000) / 997;
 
+        // forge-lint: disable-next-item(boolean-cst)
         if (leftSide < rightSide) return (false, 0);
 
         // compute the amount that must be sent to move the price to the profit-maximizing price

--- a/test/utils/mocks/creditors/CreditorMock.sol
+++ b/test/utils/mocks/creditors/CreditorMock.sol
@@ -62,6 +62,7 @@ contract CreditorMock is Creditor {
         openPosition_ = openPosition[account];
     }
 
+    // forge-lint: disable-next-item(empty-block)
     function _flashActionCallback(address, bytes calldata) internal override { }
 
     function setOpenPosition(address account, uint256 openPosition_) external {

--- a/test/utils/mocks/oracles/ArcadiaOracle.sol
+++ b/test/utils/mocks/oracles/ArcadiaOracle.sol
@@ -79,6 +79,7 @@ contract ArcadiaOracle is Owned {
         unchecked {
             latestRoundId++;
         }
+        // forge-lint: disable-next-item(unsafe-typecast)
         transmissions[latestRoundId] = Transmission({ answer: _answer, timestamp: uint64(block.timestamp) });
     }
 

--- a/test/utils/mocks/oracles/RevertingOracle.sol
+++ b/test/utils/mocks/oracles/RevertingOracle.sol
@@ -5,6 +5,7 @@
 pragma solidity ^0.8.0;
 
 contract RevertingOracle {
+    // forge-lint: disable-next-item(uninitialized-state)
     uint8 public decimals;
 
     function latestRoundData() public pure returns (uint80, int256, uint256, uint256, uint80) {

--- a/test/utils/mocks/proxy/RevertingProxy.sol
+++ b/test/utils/mocks/proxy/RevertingProxy.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.30;
  * @dev Implementation based on ERC1967: Proxy Storage Slots.
  * See https://eips.ethereum.org/EIPS/eip-1967.
  */
+// forge-lint: disable-next-item(locked-ether)
 contract RevertingProxy {
     /* //////////////////////////////////////////////////////////////
                                 CONSTANTS

--- a/test/utils/mocks/tokens/ERC1155Mock.sol
+++ b/test/utils/mocks/tokens/ERC1155Mock.sol
@@ -9,6 +9,7 @@ contract ERC1155Mock is ERC1155 {
 
     // forge-lint: disable-next-line(mixed-case-variable)
     string baseURI;
+    // forge-lint: disable-next-item(uninitialized-state)
     address owner;
     mapping(uint256 => string) _uri;
 
@@ -51,6 +52,7 @@ contract ERC1155Mock is ERC1155 {
      * @return uri of the token or an empty string if it does not exist
      */
     function uri(uint256 id) public view override returns (string memory) {
+        // forge-lint: disable-next-item(encode-packed-collision)
         return bytes(_uri[id]).length > 0 ? _uri[id] : string(abi.encodePacked(baseURI, id.toString()));
     }
 }

--- a/test/utils/mocks/tokens/ERC721Mock.sol
+++ b/test/utils/mocks/tokens/ERC721Mock.sol
@@ -32,6 +32,7 @@ contract ERC721Mock is ERC721 {
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         require(_ownerOf[tokenId] != address(0), "ERC721Metadata: URI query for nonexistent token");
         string memory currentBaseURI = baseURI;
+        // forge-lint: disable-next-item(encode-packed-collision)
         return bytes(currentBaseURI).length > 0 ? string(abi.encodePacked(currentBaseURI, tokenId.toString())) : "";
     }
 


### PR DESCRIPTION
Mark the forge 1.8 lint findings that are intentional with inline directives, per site in src and at contract level in the tests. Rules that fire across the whole codebase go in exclude_lints instead.

Needs forge 1.8.1, directives on findings reported in an inherited file were ignored before that.

Also drops dynamic_test_linking = false and unchecked_cheatcode_artifacts = true, and bumps forge-std, solady, merkl-contracts and v4-periphery. No deployed bytecode changes, only the test contracts differ through forge-std.
