### PR TITLE
♻️ Bound fuzz inputs instead of rejecting them

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -42,8 +42,9 @@ fs_permissions = [{ access = "read", path = "./out"}, { access = "write", path =
 ignored_error_codes = [2394, 2424, 3860, 4591, 5574, 8429]
 # Test-only submodules: not used in src/, safe to suppress all warnings.
 ignored_warnings_from = [
-    "lib/openzeppelin-contracts-v4.9/",
+    "lib/forge-std-v1.13/",
     "lib/openzeppelin-contracts-upgradeable-v4.9/",
+    "lib/openzeppelin-contracts-v4.9/",
     "lib/slipstream/",
 ]
 
@@ -59,20 +60,37 @@ tab_width = 4
 exclude_lints = [
     "asm-keccak256",
     "calls-loop",
+    "costly-loop",
+    "inline-assembly",
+    "internal-function-used-once",
+    "literal-instead-of-constant",
+    "low-level-calls",
     "missing-events-access-control",
+    "missing-inheritance",
     "missing-zero-check",
+    "multi-contract-file",
     "non-reentrant-not-first",
+    "pragma-inconsistent",
     "reentrancy-events",
     "require-revert-in-loop",
     "uninitialized-local",
     "unsafe-cheatcode",
+    "unused-error",
     "unused-return",
     "unwrapped-modifier-logic",
 ]
 ignore = [
-    "**/merkl/**/*",
     "**/RemoveMerklOperator.fuzz.t.sol",
     "**/SetMerklOperators.fuzz.t.sol",
+    "**/merkl/**/*",
+    "**/test/CompilePragma7Dot6.t.sol",
+    "**/test/utils/extensions/CLQuoterV2Extension.sol",
+    "**/test/utils/extensions/QuoterV2Extension.sol",
+    "**/test/utils/fixtures/slipstream/extensions/CLPoolExtension.sol",
+    "**/test/utils/fixtures/uniswap-v3/extensions/NonfungiblePositionManagerExtension.sol",
+    "**/test/utils/fixtures/uniswap-v3/extensions/UniswapV3FactoryExtension.sol",
+    "**/test/utils/fixtures/uniswap-v3/extensions/UniswapV3PoolDeployerExtension.sol",
+    "**/test/utils/fixtures/uniswap-v3/extensions/UniswapV3PoolExtension.sol",
 ]
 
 [profile.dev]

--- a/src/abstracts/Creditor.sol
+++ b/src/abstracts/Creditor.sol
@@ -29,6 +29,7 @@ abstract contract Creditor is ICreditor {
                                 EVENTS
     ////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(event-fields)
     event RiskManagerUpdated(address riskManager);
     event ValidAccountVersionsUpdated(uint256 indexed accountVersion, bool valid);
 

--- a/src/accounts/AccountPlaceholder.sol
+++ b/src/accounts/AccountPlaceholder.sol
@@ -76,6 +76,7 @@ contract AccountPlaceholder is AccountStorageV1, IAccount {
      * @dev Starts the cool-down period during which ownership cannot be transferred.
      * This prevents the old Owner from frontrunning a transferFrom().
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier updateActionTimestamp() {
         // forge-lint: disable-next-item(unsafe-typecast)
         lastActionTimestamp = uint32(block.timestamp);

--- a/src/accounts/AccountStorageV1.sol
+++ b/src/accounts/AccountStorageV1.sol
@@ -23,6 +23,7 @@ abstract contract AccountStorageV1 {
     // forge-lint: disable-next-item(uninitialized-state)
     bool public inAuction;
     // Flag Indicating if a function is locked to protect against reentrancy.
+    // forge-lint: disable-next-item(unused-state-variables)
     uint8 internal locked;
     // Used to prevent the old Owner from frontrunning a transferFrom().
     // The Timestamp of the last account action, that might be disadvantageous for a new Owner
@@ -53,14 +54,19 @@ abstract contract AccountStorageV1 {
     address public numeraire;
 
     // Array with all the contract addresses of ERC20 tokens in the account.
+    // forge-lint: disable-next-item(unused-state-variables)
     address[] internal erc20Stored;
     // Array with all the contract addresses of ERC721 tokens in the account.
+    // forge-lint: disable-next-item(unused-state-variables)
     address[] internal erc721Stored;
     // Array with all the contract addresses of ERC1155 tokens in the account.
+    // forge-lint: disable-next-item(unused-state-variables)
     address[] internal erc1155Stored;
     // Array with all the corresponding ids for each ERC721 token in the account.
+    // forge-lint: disable-next-item(unused-state-variables)
     uint256[] internal erc721TokenIds;
     // Array with all the corresponding ids for each ERC1155 token in the account.
+    // forge-lint: disable-next-item(unused-state-variables)
     uint256[] internal erc1155TokenIds;
 
     // Map asset => balance.

--- a/src/accounts/AccountV3.sol
+++ b/src/accounts/AccountV3.sol
@@ -111,8 +111,10 @@ contract AccountV3 is AccountStorageV1, IAccount {
     /**
      * @dev Throws if called by any address other than an Asset Manager or the owner.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyAssetManager() {
         // A custom error would need to read out owner + isAssetManager storage
+        // forge-lint: disable-next-line(custom-errors)
         require(msg.sender == owner || isAssetManager[owner][msg.sender], "A: Only Asset Manager");
         _;
     }
@@ -120,6 +122,7 @@ contract AccountV3 is AccountStorageV1, IAccount {
     /**
      * @dev Throws if called by any address other than the Creditor.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyCreditor() {
         if (msg.sender != creditor) revert AccountErrors.OnlyCreditor();
         _;

--- a/src/accounts/AccountV4.sol
+++ b/src/accounts/AccountV4.sol
@@ -85,8 +85,10 @@ contract AccountV4 is AccountStorageV1, IAccount {
     /**
      * @dev Throws if called by any address other than an Asset Manager or the owner.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyAssetManager() {
         // A custom error would need to read out owner + isAssetManager storage
+        // forge-lint: disable-next-line(custom-errors)
         require(msg.sender == owner || isAssetManager[owner][msg.sender], "A: Only Asset Manager");
         _;
     }

--- a/src/accounts/helpers/AccountsGuard.sol
+++ b/src/accounts/helpers/AccountsGuard.sol
@@ -60,6 +60,7 @@ contract AccountsGuard is Owned {
     /**
      * @dev Throws when caller is not the guardian.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyGuardian() {
         if (msg.sender != guardian) revert OnlyGuardian();
         _;
@@ -68,6 +69,7 @@ contract AccountsGuard is Owned {
     /**
      * @dev Throws if the functionalities are paused.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier whenNotPaused() {
         if (paused) revert Paused();
         _;

--- a/src/asset-modules/Aerodrome-Finance/interfaces/IAeroFactory.sol
+++ b/src/asset-modules/Aerodrome-Finance/interfaces/IAeroFactory.sol
@@ -1,9 +1,4 @@
-/**
- * Created by Arcadia Finance
- * https://www.arcadia.finance
- *
- * SPDX-License-Identifier: MIT
- */
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IAeroFactory {

--- a/src/asset-modules/Aerodrome-Finance/interfaces/IAeroGauge.sol
+++ b/src/asset-modules/Aerodrome-Finance/interfaces/IAeroGauge.sol
@@ -1,9 +1,4 @@
-/**
- * Created by Arcadia Finance
- * https://www.arcadia.finance
- *
- * SPDX-License-Identifier: MIT
- */
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IAeroGauge {

--- a/src/asset-modules/Aerodrome-Finance/interfaces/IAeroPool.sol
+++ b/src/asset-modules/Aerodrome-Finance/interfaces/IAeroPool.sol
@@ -1,9 +1,4 @@
-/**
- * Created by Arcadia Finance
- * https://www.arcadia.finance
- *
- * SPDX-License-Identifier: MIT
- */
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IAeroPool {

--- a/src/asset-modules/Aerodrome-Finance/interfaces/IAeroVoter.sol
+++ b/src/asset-modules/Aerodrome-Finance/interfaces/IAeroVoter.sol
@@ -1,9 +1,4 @@
-/**
- * Created by Arcadia Finance
- * https://www.arcadia.finance
- *
- * SPDX-License-Identifier: MIT
- */
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IAeroVoter {

--- a/src/asset-modules/Slipstream/libraries/PoolAddress.sol
+++ b/src/asset-modules/Slipstream/libraries/PoolAddress.sol
@@ -24,6 +24,7 @@ library PoolAddress {
         view
         returns (address pool)
     {
+        // forge-lint: disable-next-line(custom-errors)
         require(token0 < token1);
         pool = predictDeterministicAddress({
             master: ICLFactory(factory).poolImplementation(),
@@ -43,8 +44,10 @@ library PoolAddress {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             let ptr := mload(0x40)
+            // forge-lint: disable-next-line(too-many-digits)
             mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
             mstore(add(ptr, 0x14), shl(0x60, master))
+            // forge-lint: disable-next-line(too-many-digits)
             mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
             mstore(add(ptr, 0x38), shl(0x60, deployer))
             mstore(add(ptr, 0x4c), salt)

--- a/src/asset-modules/UniswapV3/libraries/FixedPoint128.sol
+++ b/src/asset-modules/UniswapV3/libraries/FixedPoint128.sol
@@ -5,5 +5,6 @@ pragma solidity ^0.8.34;
 /// @title FixedPoint128
 /// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
 library FixedPoint128 {
+    // forge-lint: disable-next-item(too-many-digits)
     uint256 internal constant Q128 = 0x100000000000000000000000000000000;
 }

--- a/src/asset-modules/UniswapV3/libraries/FixedPoint96.sol
+++ b/src/asset-modules/UniswapV3/libraries/FixedPoint96.sol
@@ -7,5 +7,6 @@ pragma solidity ^0.8.34;
 /// @dev Used in SqrtPriceMath.sol
 library FixedPoint96 {
     uint8 internal constant RESOLUTION = 96;
+    // forge-lint: disable-next-item(too-many-digits)
     uint256 internal constant Q96 = 0x1000000000000000000000000;
 }

--- a/src/asset-modules/UniswapV3/libraries/FullMath.sol
+++ b/src/asset-modules/UniswapV3/libraries/FullMath.sol
@@ -29,6 +29,7 @@ library FullMath {
 
             // Handle non-overflow cases, 256 by 256 division
             if (prod1 == 0) {
+                // forge-lint: disable-next-line(custom-errors)
                 require(denominator > 0);
                 assembly {
                     result := div(prod0, denominator)
@@ -38,6 +39,7 @@ library FullMath {
 
             // Make sure the result is less than 2**256.
             // Also prevents denominator == 0
+            // forge-lint: disable-next-line(custom-errors)
             require(denominator > prod1);
 
             ///////////////////////////////////////////////
@@ -112,6 +114,7 @@ library FullMath {
     function mulDivRoundingUp(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
         result = mulDiv(a, b, denominator);
         if (mulmod(a, b, denominator) > 0) {
+            // forge-lint: disable-next-line(custom-errors)
             require(result < type(uint256).max);
             result++;
         }

--- a/src/asset-modules/UniswapV3/libraries/PoolAddress.sol
+++ b/src/asset-modules/UniswapV3/libraries/PoolAddress.sol
@@ -24,6 +24,7 @@ library PoolAddress {
         pure
         returns (address pool)
     {
+        // forge-lint: disable-next-line(custom-errors)
         require(token0 < token1);
         pool = address(
             uint160(

--- a/src/asset-modules/UniswapV3/libraries/TickMath.sol
+++ b/src/asset-modules/UniswapV3/libraries/TickMath.sol
@@ -19,13 +19,16 @@ library TickMath {
     /// @param tick The input tick for the above formula
     /// @return sqrtPriceX96 A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
     /// at the given tick
+    // forge-lint: disable-next-item(cyclomatic-complexity)
     function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
         unchecked {
             uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
+            // forge-lint: disable-next-line(custom-errors)
             require(absTick <= uint256(uint24(MAX_TICK)), "T");
 
             uint256 ratio =
-                absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
+            // forge-lint: disable-next-line(too-many-digits)
+            absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
             if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
             if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
             if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
@@ -63,6 +66,7 @@ library TickMath {
     function getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
         unchecked {
             // second inequality must be < because the price can never reach the price at the max tick
+            // forge-lint: disable-next-line(custom-errors)
             require(sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 < MAX_SQRT_RATIO, "R");
             uint256 ratio = uint256(sqrtPriceX96) << 32;
 

--- a/src/asset-modules/UniswapV4/UniswapV4HooksRegistry.sol
+++ b/src/asset-modules/UniswapV4/UniswapV4HooksRegistry.sol
@@ -49,6 +49,7 @@ contract UniswapV4HooksRegistry is AssetModule {
                                 EVENTS
     ////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(event-fields)
     event AssetModuleAdded(address assetModule);
     event HooksAdded(address indexed hooks, address indexed assetModule);
 
@@ -68,6 +69,7 @@ contract UniswapV4HooksRegistry is AssetModule {
      * @param creditor The contract address of the Creditor.
      * @dev Only the Risk Manager of a Creditor can call functions with this modifier.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyRiskManager(address creditor) {
         if (msg.sender != ICreditor(creditor).riskManager()) revert RegistryErrors.Unauthorized();
         _;

--- a/src/guardians/FactoryGuardian.sol
+++ b/src/guardians/FactoryGuardian.sol
@@ -40,6 +40,7 @@ abstract contract FactoryGuardian is BaseGuardian {
     /**
      * @dev Throws if the createAccount functionality is paused.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier whenCreateNotPaused() {
         if (createPaused) revert GuardianErrors.FunctionIsPaused();
         _;

--- a/src/registries/RegistryL1.sol
+++ b/src/registries/RegistryL1.sol
@@ -80,8 +80,10 @@ contract RegistryL1 is IRegistry, RegistryGuardian {
     ////////////////////////////////////////////////////////////// */
 
     event AssetAdded(address indexed assetAddress, address indexed assetModule);
+    // forge-lint: disable-next-item(event-fields)
     event AssetModuleAdded(address assetModule);
     event OracleAdded(uint256 indexed oracleId, address indexed oracleModule);
+    // forge-lint: disable-next-item(event-fields)
     event OracleModuleAdded(address oracleModule);
 
     /* //////////////////////////////////////////////////////////////
@@ -107,6 +109,7 @@ contract RegistryL1 is IRegistry, RegistryGuardian {
     /**
      * @dev Only Oracle Modules can call functions with this modifier.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyOracleModule() {
         if (!isOracleModule[msg.sender]) revert RegistryErrors.OnlyOracleModule();
         _;

--- a/src/registries/RegistryL2.sol
+++ b/src/registries/RegistryL2.sol
@@ -88,8 +88,10 @@ contract RegistryL2 is IRegistry, RegistryGuardian {
     ////////////////////////////////////////////////////////////// */
 
     event AssetAdded(address indexed assetAddress, address indexed assetModule);
+    // forge-lint: disable-next-item(event-fields)
     event AssetModuleAdded(address assetModule);
     event OracleAdded(uint256 indexed oracleId, address indexed oracleModule);
+    // forge-lint: disable-next-item(event-fields)
     event OracleModuleAdded(address oracleModule);
 
     /* //////////////////////////////////////////////////////////////
@@ -115,6 +117,7 @@ contract RegistryL2 is IRegistry, RegistryGuardian {
     /**
      * @dev Only Oracle Modules can call functions with this modifier.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyOracleModule() {
         if (!isOracleModule[msg.sender]) revert RegistryErrors.OnlyOracleModule();
         _;
@@ -134,6 +137,7 @@ contract RegistryL2 is IRegistry, RegistryGuardian {
      * @dev Throws if the sequencer is down,
      * or the Creditor specific grace period after sequencer is back up did not pass.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier sequencerNotDown(address creditor) {
         (, bool sequencerDown) = _isSequencerDown(creditor);
         if (sequencerDown) revert RegistryErrors.SequencerDown();

--- a/test/fuzz/AssetValuationLib/CalculateCollateralFactor.fuzz.t.sol
+++ b/test/fuzz/AssetValuationLib/CalculateCollateralFactor.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../src/librar
 /**
  * @notice Fuzz tests for the function "calculateCollateralFactor" of contract "AssetValuationLib".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateCollateralFactor_AssetValuationLib_Fuzz_Test is AssetValuationLib_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -36,8 +37,8 @@ contract CalculateCollateralFactor_AssetValuationLib_Fuzz_Test is AssetValuation
         values[1].assetValue = secondValue;
 
         // And: collateral factors are within allowed ranges
-        vm.assume(firstCollFactor <= AssetValuationLib.ONE_4);
-        vm.assume(secondCollFactor <= AssetValuationLib.ONE_4);
+        firstCollFactor = uint16(bound(firstCollFactor, 0, AssetValuationLib.ONE_4));
+        secondCollFactor = uint16(bound(secondCollFactor, 0, AssetValuationLib.ONE_4));
 
         values[0].collateralFactor = firstCollFactor;
         values[1].collateralFactor = secondCollFactor;

--- a/test/fuzz/AssetValuationLib/CalculateLiquidationValue.fuzz.t.sol
+++ b/test/fuzz/AssetValuationLib/CalculateLiquidationValue.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../src/librar
 /**
  * @notice Fuzz tests for the function "calculateLiquidationValue" of contract "AssetValuationLib".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateLiquidationValue_AssetValuationLib_Fuzz_Test is AssetValuationLib_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -36,8 +37,8 @@ contract CalculateLiquidationValue_AssetValuationLib_Fuzz_Test is AssetValuation
         values[1].assetValue = secondValue;
 
         // And: Liquidation factors are within allowed ranges
-        vm.assume(firstLiqFactor <= AssetValuationLib.ONE_4);
-        vm.assume(secondLiqFactor <= AssetValuationLib.ONE_4);
+        firstLiqFactor = uint16(bound(firstLiqFactor, 0, AssetValuationLib.ONE_4));
+        secondLiqFactor = uint16(bound(secondLiqFactor, 0, AssetValuationLib.ONE_4));
 
         values[0].liquidationFactor = firstLiqFactor;
         values[1].liquidationFactor = secondLiqFactor;

--- a/test/fuzz/Factory/CreateAccount.fuzz.t.sol
+++ b/test/fuzz/Factory/CreateAccount.fuzz.t.sol
@@ -19,7 +19,7 @@ import { Utils } from "../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "createAccount" of contract "Factory".
  */
-// forge-lint: disable-next-item(weak-prng)
+// forge-lint: disable-next-item(unsafe-typecast,weak-prng)
 contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -62,8 +62,8 @@ contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
         AccountVariableVersion account_ = new AccountVariableVersion(0, address(factory));
 
         vm.assume(versionsToBlock.length < 10 && versionsToBlock.length > 0);
-        vm.assume(uint256(versionsToMake) + 1 < type(uint8).max);
-        vm.assume(accountVersion <= versionsToMake + 1);
+        versionsToMake = uint8(bound(versionsToMake, 0, type(uint8).max - 2));
+        accountVersion = uint8(bound(accountVersion, 0, versionsToMake + 1));
         uint256 nextVersion = factory.latestAccountVersion() + 1;
         for (uint256 i; i < versionsToMake; ++i) {
             // Create account logic with the right version
@@ -97,7 +97,7 @@ contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
     function testFuzz_Revert_createAccount_RevertingProxy(address sender, uint32 salt) public {
         // We assume that salt > 0 as we already deployed an Account with all inputs to 0
-        vm.assume(salt > 0);
+        salt = uint32(bound(salt, 1, type(uint32).max));
         vm.assume(sender != address(0));
 
         // Get bytecode of Reverting Proxy, need to compile it first.
@@ -122,7 +122,7 @@ contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
     function testFuzz_Revert_createAccount_ContractCollision(address sender, uint32 salt) public {
         // We assume that salt > 0 as we already deployed an Account with all inputs to 0
-        vm.assume(salt > 0);
+        salt = uint32(bound(salt, 1, type(uint32).max));
         vm.assume(sender != address(0));
 
         vm.broadcast(sender);
@@ -157,7 +157,7 @@ contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
     function testFuzz_Success_createAccount_DeployAccountWithNoCreditor(address sender, uint32 salt) public {
         // We assume that salt > 0 as we already deployed an Account with all inputs to 0
-        vm.assume(salt > 0);
+        salt = uint32(bound(salt, 1, type(uint32).max));
         vm.assume(sender != address(0));
 
         uint256 amountBefore = factory.allAccountsLength();
@@ -184,7 +184,7 @@ contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
     function testFuzz_Success_createAccount_DeployAccountWithCreditor(address sender, uint32 salt) public {
         // We assume that salt > 0 as we already deployed an Account with all inputs to 0
-        vm.assume(salt > 0);
+        salt = uint32(bound(salt, 1, type(uint32).max));
         vm.assume(sender != address(0));
 
         uint256 amountBefore = factory.allAccountsLength();
@@ -212,7 +212,7 @@ contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
 
     function testFuzz_Success_createAccount_DeployNewProxyWithLogicOwner(uint32 salt, address sender) public {
         // We assume that salt > 0 as we already deployed an Account with all inputs to 0
-        vm.assume(salt > 0);
+        salt = uint32(bound(salt, 1, type(uint32).max));
         vm.assume(sender != address(0));
 
         uint256 amountBefore = factory.allAccountsLength();
@@ -233,7 +233,7 @@ contract CreateAccount_Factory_Fuzz_Test is Factory_Fuzz_Test {
         address sender1
     ) public {
         // We assume that salt > 0 as we already deployed an Account with all inputs to 0
-        vm.assume(salt > 0);
+        salt = uint32(bound(salt, 1, type(uint32).max));
         // forge-lint: disable-next-line(unsafe-typecast)
         vm.assume(uint32(uint160(sender0)) != uint32(uint160(sender1)));
         vm.assume(sender0 != address(0));

--- a/test/fuzz/Factory/UpgradeAccountVersion.fuzz.t.sol
+++ b/test/fuzz/Factory/UpgradeAccountVersion.fuzz.t.sol
@@ -50,7 +50,7 @@ contract UpgradeAccountVersion_Factory_Fuzz_Test is Factory_Fuzz_Test {
     function testFuzz_Revert_upgradeAccountVersion_VersionNotAllowed(uint256 version, bytes32[] calldata proofs)
         public
     {
-        vm.assume(version > factory.latestAccountVersion());
+        version = bound(version, factory.latestAccountVersion() + 1, type(uint256).max);
 
         vm.startPrank(users.accountOwner);
         vm.expectRevert(FactoryErrors.InvalidUpgrade.selector);

--- a/test/fuzz/Fuzz.t.sol
+++ b/test/fuzz/Fuzz.t.sol
@@ -27,7 +27,7 @@ import { NativeTokenAMExtension } from "../utils/extensions/NativeTokenAMExtensi
  * (eg. a uint256 from 0 to type(uint256).max), unless the parameter/variable is bound by an invariant.
  * If this case, said invariant must be explicitly tested in the invariant tests.
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(reentrancy-no-eth,unsafe-typecast)
 abstract contract Fuzz_Test is Base_Test, ArcadiaAccountsFixture {
     /*//////////////////////////////////////////////////////////////////////////
                                      VARIABLES

--- a/test/fuzz/accounts/AccountV3/AuctionBid.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/AuctionBid.fuzz.t.sol
@@ -81,7 +81,7 @@ contract AuctionBid_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     }
 
     function testFuzz_Revert_AuctionBuy_UnknownAssetType(address bidder, uint96 assetType) public {
-        vm.assume(assetType > 3);
+        assetType = uint96(bound(assetType, 3 + 1, type(uint96).max));
 
         vm.startPrank(users.owner);
         AssetModuleMock assetModule = new AssetModuleMock(users.owner, address(registry), assetType);

--- a/test/fuzz/accounts/AccountV3/CloseMarginAccount.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/CloseMarginAccount.fuzz.t.sol
@@ -70,7 +70,7 @@ contract CloseMarginAccount_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         account.openMarginAccount(address(creditorStable1));
 
         // Mock debt.
-        vm.assume(debt_ > 0);
+        debt_ = bound(debt_, 1, type(uint256).max);
         creditorStable1.setOpenPosition(address(account), debt_);
 
         vm.startPrank(users.accountOwner);

--- a/test/fuzz/accounts/AccountV3/Deposit.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/Deposit.fuzz.t.sol
@@ -72,7 +72,7 @@ contract Deposit_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     }
 
     function testFuzz_Revert_deposit_tooManyAssets(uint8 arrLength) public {
-        vm.assume(arrLength > accountExtension.ASSET_LIMIT() && arrLength < 50);
+        arrLength = uint8(bound(arrLength, accountExtension.ASSET_LIMIT() + 1, 49));
 
         address[] memory assetAddresses = new address[](arrLength);
 
@@ -90,10 +90,10 @@ contract Deposit_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     }
 
     function testFuzz_Revert_deposit_tooManyAssetsNotAtOnce(uint8 arrLength, uint8 amountToken1) public {
-        vm.assume(uint256(arrLength) + 1 > accountExtension.ASSET_LIMIT() && arrLength < 50);
+        arrLength = uint8(bound(arrLength, accountExtension.ASSET_LIMIT(), 49));
 
         //deposit a single asset first
-        vm.assume(amountToken1 > 0);
+        amountToken1 = uint8(bound(amountToken1, 1, type(uint8).max));
         depositErc20InAccount(mockERC20.token1, amountToken1, users.accountOwner, address(accountExtension));
 
         //then try to go over the asset limit
@@ -214,7 +214,7 @@ contract Deposit_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     }
 
     function testFuzz_Revert_deposit_UnknownAssetType(uint96 assetType, address assetModule) public {
-        vm.assume(assetType > 3);
+        assetType = uint96(bound(assetType, 3 + 1, type(uint96).max));
 
         registry.setAssetInformation(address(mockERC20.token1), assetType, assetModule);
 

--- a/test/fuzz/accounts/AccountV3/FlashAction.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/FlashAction.fuzz.t.sol
@@ -125,7 +125,7 @@ contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture 
     }
 
     function testFuzz_Revert_flashAction_tooManyAssets(uint8 arrLength, bytes calldata signature) public {
-        vm.assume(arrLength > accountExtension.ASSET_LIMIT() && arrLength < 50);
+        arrLength = uint8(bound(arrLength, accountExtension.ASSET_LIMIT() + 1, 49));
 
         address[] memory assetAddresses = new address[](arrLength);
         uint256[] memory assetIds = new uint256[](arrLength);
@@ -177,7 +177,7 @@ contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture 
         uint32 minimumMargin,
         bytes calldata signature
     ) public {
-        vm.assume(debtAmount > 0);
+        debtAmount = uint128(bound(debtAmount, 1, type(uint128).max));
 
         // Init account
         vm.startPrank(users.accountOwner);
@@ -198,10 +198,6 @@ contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture 
         uint256 token1AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
         uint256 token2AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
         uint256 token1ToToken2Ratio = rates.token1ToUsd / rates.token2ToUsd;
-
-        vm.assume(
-            token1AmountForAction + ((uint256(debtAmount) + minimumMargin) * token1ToToken2Ratio) < type(uint256).max
-        );
 
         creditorStable1.setOpenPosition(address(accountNotInitialised), debtAmount);
 
@@ -564,8 +560,7 @@ contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture 
         uint128 debtAmount,
         bytes calldata signature
     ) public {
-        vm.assume(time > 2 days);
-        vm.assume(time > 2 days);
+        time = uint32(bound(time, 2 days + 1, type(uint32).max));
         accountNotInitialised.setMinimumMargin(minimumMargin);
         accountNotInitialised.setLocked(1);
         accountNotInitialised.setOwner(users.accountOwner);
@@ -586,10 +581,6 @@ contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture 
         uint256 token2AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
         uint256 stable1AmountForAction = 500 * 10 ** Constants.STABLE_DECIMALS;
         uint256 token1ToToken2Ratio = rates.token1ToUsd / rates.token2ToUsd;
-
-        vm.assume(
-            token1AmountForAction + ((uint256(debtAmount) + minimumMargin) * token1ToToken2Ratio) < type(uint256).max
-        );
 
         // We increase the price of token 2 in order to avoid to end up with unhealthy state of account
         vm.startPrank(users.transmitter);
@@ -771,7 +762,7 @@ contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture 
         uint32 time,
         bytes calldata signature
     ) public {
-        vm.assume(time > 2 days);
+        time = uint32(bound(time, 2 days + 1, type(uint32).max));
         vm.assume(users.accountOwner != assetManager);
         vm.startPrank(users.accountOwner);
         accountNotInitialised.setMinimumMargin(minimumMargin);
@@ -794,10 +785,6 @@ contract FlashAction_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permit2Fixture 
         uint256 token1AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
         uint256 token2AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
         uint256 token1ToToken2Ratio = rates.token1ToUsd / rates.token2ToUsd;
-
-        vm.assume(
-            token1AmountForAction + ((uint256(debtAmount) + minimumMargin) * token1ToToken2Ratio) < type(uint256).max
-        );
 
         bytes memory callData;
         {

--- a/test/fuzz/accounts/AccountV3/FlashActionByCreditor.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/FlashActionByCreditor.fuzz.t.sol
@@ -682,7 +682,7 @@ contract FlashActionByCreditor_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permi
         bytes calldata signature,
         uint32 time
     ) public {
-        vm.assume(time > 2 days);
+        time = uint32(bound(time, 2 days + 1, type(uint32).max));
         vm.prank(users.accountOwner);
         accountExtension.openMarginAccount(address(creditorToken1));
 
@@ -695,11 +695,6 @@ contract FlashActionByCreditor_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test, Permi
             uint256 token1AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
             uint256 token2AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
             uint256 token1ToToken2Ratio = rates.token1ToUsd / rates.token2ToUsd;
-
-            vm.assume(
-                token1AmountForAction + ((uint256(debtAmount) + minimumMargin) * token1ToToken2Ratio)
-                    < type(uint256).max
-            );
 
             // We increase the price of token 2 in order to avoid to end up with unhealthy state of accountExtension
             vm.startPrank(users.transmitter);

--- a/test/fuzz/accounts/AccountV3/GetFreeMargin.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/GetFreeMargin.fuzz.t.sol
@@ -30,29 +30,23 @@ contract GetFreeMargin_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
 
-    // TODO: add processDeposit and withdrawal when opening and closing a margin account.
-    /*     function testFuzz_Success_getFreeMargin_CreditorNotSet(
-        uint256 openDebt,
-        uint256 minimumMargin,
-        uint128 collateralValue
-    ) public {
-        // Test-case: creditor is not set.
-        accountExtension.setCreditor(address(0));
+    function testFuzz_Success_getFreeMargin_CreditorNotSet(uint112 collateralValue) public {
+        // Given: No creditor is set.
+        vm.prank(users.accountOwner);
+        accountExtension.closeMarginAccount();
 
-        // Set minimumMargin
-        accountExtension.setMinimumMargin(uint96(minimumMargin));
-
-        // Mock initial debt.
-        creditorStable1.setOpenPosition(address(accountExtension), openDebt);
-
-        // Given: "exposure" is strictly smaller than "maxExposure".
+        // And: "exposure" is strictly smaller than "maxExposure".
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        // Set Liquidation Value of assets (Liquidation value of token1 is 1:1 the amount of token1 tokens).
+        // And: Assets are deposited.
         depositErc20InAccount(accountExtension, mockERC20.stable1, collateralValue);
 
-        assertEq(collateralValue, accountExtension.getFreeMargin());
-    } */
+        // Then: Without a Creditor no risk factors are set, so the Account has no collateral value
+        // and no free margin, independent of the assets deposited.
+        assertEq(accountExtension.getUsedMargin(), 0);
+        assertEq(accountExtension.getCollateralValue(), 0);
+        assertEq(accountExtension.getFreeMargin(), 0);
+    }
 
     function testFuzz_Success_getFreeMargin_CreditorIsSet_NonZeroFreeMargin(
         uint256 openDebt,

--- a/test/fuzz/accounts/AccountV3/GetFreeMargin.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/GetFreeMargin.fuzz.t.sol
@@ -54,7 +54,7 @@ contract GetFreeMargin_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         uint112 collateralValue
     ) public {
         // No overflow of Used Margin.
-        vm.assume(openDebt <= type(uint256).max - minimumMargin);
+        openDebt = bound(openDebt, 0, type(uint256).max - minimumMargin);
 
         // "exposure" is strictly smaller than "maxExposure" -> collateralValue < type(uint128).max.
         // Non zero free margin -> "collateralValue" bigger than "usedMargin".

--- a/test/fuzz/accounts/AccountV3/GetUsedMargin.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/GetUsedMargin.fuzz.t.sol
@@ -39,7 +39,7 @@ contract GetUsedMargin_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
 
     function testFuzz_Success_getUsedMargin_CreditorIsSet(uint256 openDebt, uint96 minimumMargin) public {
         // No overflow of Used Margin.
-        vm.assume(openDebt <= type(uint256).max - minimumMargin);
+        openDebt = bound(openDebt, 0, type(uint256).max - minimumMargin);
 
         // Test-case: creditor set.
 

--- a/test/fuzz/accounts/AccountV3/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/StartLiquidation.fuzz.t.sol
@@ -67,9 +67,6 @@ contract startLiquidation_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         // "exposure" is strictly smaller than "maxExposure".
         depositAmountToken1 = uint112(bound(depositAmountToken1, 1, type(uint112).max - 1));
 
-        // Given: openDebt > 0
-        openDebt = bound(openDebt, 1, type(uint112).max - minimumMargin);
-
         address[] memory assetAddresses = new address[](1);
         assetAddresses[0] = address(mockERC20.token1);
 
@@ -83,7 +80,6 @@ contract startLiquidation_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         vm.prank(address(factory));
         accountExtension2.initialize(users.accountOwner, address(registry), address(creditorToken1));
         accountExtension2.setMinimumMargin(minimumMargin);
-        creditorToken1.setOpenPosition(address(accountExtension2), openDebt);
         stdstore.target(address(factory))
             .sig(factory.isAccount.selector)
             .with_key(address(accountExtension2))
@@ -93,8 +89,13 @@ contract startLiquidation_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
             accountExtension2.numeraire(), accountExtension2.creditor(), assetAddresses, assetIds, assetAmounts
         );
 
-        // Given : Liquidation value is greater than or equal to used margin
-        vm.assume(openDebt + minimumMargin <= assetValuationLib.calculateLiquidationValue(assetAndRiskValues));
+        // Given : openDebt > 0 and the liquidation value is greater than or equal to used margin.
+        uint256 liquidationValue = assetValuationLib.calculateLiquidationValue(assetAndRiskValues);
+        vm.assume(liquidationValue > minimumMargin);
+        uint256 maxOpenDebt = type(uint112).max - minimumMargin;
+        if (liquidationValue - minimumMargin < maxOpenDebt) maxOpenDebt = liquidationValue - minimumMargin;
+        openDebt = bound(openDebt, 1, maxOpenDebt);
+        creditorToken1.setOpenPosition(address(accountExtension2), openDebt);
 
         // Mint and approve token1 tokens
         vm.startPrank(users.tokenCreator);
@@ -149,9 +150,6 @@ contract startLiquidation_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         // "exposure" is strictly smaller than "maxExposure".
         depositAmountToken1 = uint112(bound(depositAmountToken1, 1, type(uint112).max - 1));
 
-        // Given: openDebt > 0
-        openDebt = bound(openDebt, 1, type(uint112).max - minimumMargin);
-
         AssetValueAndRiskFactors[] memory assetAndRiskValues;
         {
             address[] memory assetAddresses = new address[](1);
@@ -167,7 +165,6 @@ contract startLiquidation_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
             vm.prank(address(factory));
             accountExtension2.initialize(users.accountOwner, address(registry), address(creditorToken1));
             accountExtension2.setMinimumMargin(minimumMargin);
-            creditorToken1.setOpenPosition(address(accountExtension2), openDebt);
             stdstore.target(address(factory))
                 .sig(factory.isAccount.selector)
                 .with_key(address(accountExtension2))
@@ -177,8 +174,15 @@ contract startLiquidation_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
                 accountExtension2.numeraire(), accountExtension2.creditor(), assetAddresses, assetIds, assetAmounts
             );
 
-            // Given : Liquidation value is smaller than used margin
-            vm.assume(openDebt + minimumMargin > assetValuationLib.calculateLiquidationValue(assetAndRiskValues));
+            // Given : openDebt > 0 and the liquidation value is smaller than used margin.
+            uint256 liquidationValue = assetValuationLib.calculateLiquidationValue(assetAndRiskValues);
+            vm.assume(liquidationValue < type(uint112).max);
+            openDebt = bound(
+                openDebt,
+                liquidationValue > minimumMargin ? liquidationValue - minimumMargin + 1 : 1,
+                type(uint112).max - minimumMargin
+            );
+            creditorToken1.setOpenPosition(address(accountExtension2), openDebt);
 
             // Mint and approve stable1 tokens
             vm.prank(users.tokenCreator);

--- a/test/fuzz/accounts/AccountV3/UpgradeAccount.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/UpgradeAccount.fuzz.t.sol
@@ -146,7 +146,14 @@ contract UpgradeAccount_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         canReceiveERC721(newImplementation)
     {
         vm.assume(!isPrecompile(newImplementation));
+        // And: The new implementation does not overwrite a contract the upgrade path needs.
+        vm.assume(newImplementation != address(0));
+        vm.assume(newImplementation != address(vm));
         vm.assume(newImplementation != address(account));
+        vm.assume(newImplementation != address(accountV3Logic));
+        vm.assume(newImplementation != address(factory));
+        vm.assume(newImplementation != address(registry));
+        vm.assume(newImplementation != address(sequencerUptimeOracle));
 
         // Given: Creditor is set.
         vm.prank(users.accountOwner);

--- a/test/fuzz/accounts/AccountV3/Withdraw.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV3/Withdraw.fuzz.t.sol
@@ -139,7 +139,7 @@ contract Withdraw_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     }
 
     function testFuzz_Revert_withdraw_UnknownAssetType(uint96 assetType) public {
-        vm.assume(assetType > 3);
+        assetType = uint96(bound(assetType, 4, type(uint96).max));
 
         vm.startPrank(users.owner);
         AssetModuleMock assetModule = new AssetModuleMock(users.owner, address(registry), assetType);
@@ -163,7 +163,7 @@ contract Withdraw_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
     }
 
     function testFuzz_Revert_withdraw_MoreThanMaxExposure(uint256 amountWithdraw, uint112 maxExposure) public {
-        vm.assume(amountWithdraw > maxExposure);
+        amountWithdraw = bound(amountWithdraw, uint256(maxExposure) + 1, type(uint256).max);
 
         vm.startPrank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(address(creditorUsd), address(mockERC20.token1), 0, maxExposure, 0, 0);
@@ -285,7 +285,7 @@ contract Withdraw_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         vm.stopPrank();
 
         // Given: "accountOwner" deposits a number of nfts different from 1 in first account.
-        vm.assume(arrLength < accountExtension.ASSET_LIMIT());
+        arrLength = uint8(bound(arrLength, 0, accountExtension.ASSET_LIMIT() - 1));
         vm.assume(arrLength != 1);
 
         assetAddresses = new address[](arrLength);
@@ -325,18 +325,20 @@ contract Withdraw_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         debt = bound(debt, 1, type(uint256).max);
 
         // No overflow of Used Margin.
-        minimumMargin = bound(minimumMargin, 0, type(uint256).max - debt);
-        minimumMargin = bound(minimumMargin, 0, type(uint96).max);
+        minimumMargin = bound(
+            minimumMargin, 0, type(uint256).max - debt < type(uint96).max ? type(uint256).max - debt : type(uint96).max
+        );
         uint256 usedMargin = debt + minimumMargin;
 
         // "exposure" is strictly smaller than "maxExposure".
         collateralValueInitial = uint112(bound(collateralValueInitial, 0, type(uint112).max - 1));
 
-        // No underflow Withdrawal.
-        collateralValueDecrease = bound(collateralValueDecrease, 0, collateralValueInitial);
-
-        // test-case: Insufficient collateralValue after withdrawal.
-        vm.assume(collateralValueInitial - collateralValueDecrease < usedMargin);
+        // No underflow Withdrawal, test-case: Insufficient collateralValue after withdrawal.
+        collateralValueDecrease = bound(
+            collateralValueDecrease,
+            collateralValueInitial > usedMargin ? collateralValueInitial - usedMargin + 1 : 0,
+            collateralValueInitial
+        );
 
         // Set minimumMargin
         accountExtension.setMinimumMargin(uint96(minimumMargin));
@@ -504,8 +506,8 @@ contract Withdraw_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         erc1155InitialAmount = uint112(bound(erc1155InitialAmount, 0, type(uint112).max - 1));
 
         // And: total deposit amounts are bigger than zero.
-        vm.assume(erc20InitialAmount > 0);
-        vm.assume(erc1155InitialAmount > 0);
+        erc20InitialAmount = uint112(bound(erc20InitialAmount, 1, type(uint112).max));
+        erc1155InitialAmount = uint112(bound(erc1155InitialAmount, 1, type(uint112).max));
         // And: Assets don't underflow.
         erc20WithdrawAmount = uint112(bound(erc20WithdrawAmount, 0, erc20InitialAmount - 1));
         erc1155WithdrawAmount = uint112(bound(erc1155WithdrawAmount, 0, erc1155InitialAmount - 1));
@@ -650,21 +652,16 @@ contract Withdraw_AccountV3_Fuzz_Test is AccountV3_Fuzz_Test {
         uint256 minimumMargin
     ) public {
         // Test-case: With debt.
-        debt = bound(debt, 1, type(uint256).max);
-
-        // No overflow of Used Margin.
-        minimumMargin = bound(minimumMargin, 0, type(uint256).max - debt);
+        // No overflow of Used Margin, and the used margin fits in the collateral value.
         minimumMargin = bound(minimumMargin, 0, type(uint96).max);
+        debt = bound(debt, 1, type(uint112).max - 1 - minimumMargin);
         uint256 usedMargin = debt + minimumMargin;
 
         // "exposure" is strictly smaller than "maxExposure".
-        collateralValueInitial = uint112(bound(collateralValueInitial, 0, type(uint112).max - 1));
+        collateralValueInitial = uint112(bound(collateralValueInitial, usedMargin, type(uint112).max - 1));
 
-        // No underflow Withdrawal.
-        collateralValueDecrease = bound(collateralValueDecrease, 0, collateralValueInitial);
-
-        // test-case: Insufficient collateralValue after withdrawal.
-        vm.assume(collateralValueInitial - collateralValueDecrease >= usedMargin);
+        // No underflow Withdrawal, test-case: Sufficient collateralValue after withdrawal.
+        collateralValueDecrease = bound(collateralValueDecrease, 0, collateralValueInitial - usedMargin);
 
         // Set minimumMargin
         accountExtension.setMinimumMargin(uint96(minimumMargin));

--- a/test/fuzz/accounts/AccountV4/Deposit.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/Deposit.fuzz.t.sol
@@ -12,6 +12,7 @@ import { AccountV4_Fuzz_Test } from "./_AccountV4.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "deposit" of contract "AccountV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Deposit_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -59,7 +60,7 @@ contract Deposit_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
 
     function testFuzz_Revert_deposit_UnknownAssetType(uint96 assetType) public {
         // Given : assetType is > 3
-        vm.assume(assetType > 3);
+        assetType = uint96(bound(assetType, 4, type(uint96).max));
 
         address[] memory assetAddresses = new address[](1);
         assetAddresses[0] = address(mockERC20.token1);

--- a/test/fuzz/accounts/AccountV4/FlashAction.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/FlashAction.fuzz.t.sol
@@ -22,7 +22,7 @@ import { Utils } from "../../../utils/Utils.sol";
 /**
  * @notice Fuzz tests for the function "flashAction" of contract "AccountV4".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract FlashAction_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test, Permit2Fixture {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -336,8 +336,7 @@ contract FlashAction_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test, Permit2Fixture 
     }
 
     function testFuzz_Success_flashAction_Owner(uint32 time, bytes calldata signature) public {
-        vm.assume(time > 2 days);
-        vm.assume(time > 2 days);
+        time = uint32(bound(time, 2 days + 1, type(uint32).max));
 
         uint256 token1AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
         uint256 token2AmountForAction = 1000 * 10 ** Constants.TOKEN_DECIMALS;
@@ -495,7 +494,7 @@ contract FlashAction_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test, Permit2Fixture 
         uint32 time,
         bytes calldata signature
     ) public {
-        vm.assume(time > 2 days);
+        time = uint32(bound(time, 2 days + 1, type(uint32).max));
         vm.assume(users.accountOwner != assetManager);
         vm.startPrank(users.accountOwner);
         accountSpot.setAssetManager(assetManager, true);

--- a/test/fuzz/accounts/AccountV4/Withdraw.fuzz.t.sol
+++ b/test/fuzz/accounts/AccountV4/Withdraw.fuzz.t.sol
@@ -12,6 +12,7 @@ import { AccountV4_Fuzz_Test } from "./_AccountV4.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "withdraw" of contract "AccountV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Withdraw_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -55,7 +56,7 @@ contract Withdraw_AccountV4_Fuzz_Test is AccountV4_Fuzz_Test {
     }
 
     function testFuzz_Revert_withdraw_UnknownAssetType(uint96 assetType) public {
-        vm.assume(assetType > 3);
+        assetType = uint96(bound(assetType, 3 + 1, type(uint96).max));
 
         address[] memory assetAddresses = new address[](1);
         assetAddresses[0] = address(mockERC20.token1);

--- a/test/fuzz/accounts/Helpers/AccountsGuard/Lock.fuzz.t.sol
+++ b/test/fuzz/accounts/Helpers/AccountsGuard/Lock.fuzz.t.sol
@@ -98,7 +98,7 @@ contract Lock_AccountsGuard_Fuzz_Test is AccountsGuard_Fuzz_Test {
         vm.prank(users.owner);
         accountsGuard.setPauseFlag(false);
 
-        // And: The Account can sign its own transactions. Necessary for test with transient storage.
+        // And: The Account can sign its own transactions.
         privateKey = uint248(bound(privateKey, 1, type(uint248).max));
         address account_ = vm.addr(privateKey);
         factory.setAccount(account_, 11);

--- a/test/fuzz/accounts/Helpers/AccountsGuard/Lock.fuzz.t.sol
+++ b/test/fuzz/accounts/Helpers/AccountsGuard/Lock.fuzz.t.sol
@@ -7,11 +7,15 @@ pragma solidity ^0.8.0;
 import { AccountsGuard } from "../../../../../src/accounts/helpers/AccountsGuard.sol";
 import { AccountsGuard_Fuzz_Test } from "./_AccountsGuard.fuzz.t.sol";
 import { AccountsGuardHelper } from "../../../../utils/mocks/accounts/AccountsGuardHelper.sol";
+import { LibRLP } from "../../../../../lib/solady/src/utils/LibRLP.sol";
 
 /**
  * @notice Fuzz tests for the function "lock" of contract "AccountsGuard".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Lock_AccountsGuard_Fuzz_Test is AccountsGuard_Fuzz_Test {
+    using LibRLP for LibRLP.List;
+
     /* ///////////////////////////////////////////////////////////////
                              VARIABLES
     /////////////////////////////////////////////////////////////// */
@@ -89,22 +93,38 @@ contract Lock_AccountsGuard_Fuzz_Test is AccountsGuard_Fuzz_Test {
         assertEq(account_, address(accountMock));
     }
 
-    function testFuzz_Success_lock_NoUnLockCalled(bool pauseCheck) public {
-        // Skip test until we can run --isolate as additional_compiler_profiles.
-        // Otherwise transient storage is not cleared after calls within a test run.
-        vm.skip(true);
-
+    function testFuzz_Success_lock_NoUnLockCalled(bool pauseCheck, uint248 privateKey) public {
         // Given: pause flag is not set.
         vm.prank(users.owner);
         accountsGuard.setPauseFlag(false);
 
+        // And: The Account can sign its own transactions. Necessary for test with transient storage.
+        privateKey = uint248(bound(privateKey, 1, type(uint248).max));
+        address account_ = vm.addr(privateKey);
+        factory.setAccount(account_, 11);
+        vm.deal(account_, 1 ether);
+
         // And: Guard was locked in past, and not unlocked.
-        vm.prank(address(account));
+        vm.prank(account_);
         accountsGuard.lock(pauseCheck);
 
-        // When: lock is called.
+        // When: lock is called from a new transaction.
         // Then: Transaction does not revert.
-        vm.prank(address(account));
-        accountsGuard.lock(pauseCheck);
+        vm.executeTransaction(signedLock(privateKey, account_, pauseCheck));
+    }
+
+    function signedLock(uint256 privateKey, address account_, bool pauseCheck) internal view returns (bytes memory) {
+        bytes memory data = abi.encodeCall(accountsGuard.lock, (pauseCheck));
+        uint256 nonce = vm.getNonce(account_);
+
+        bytes32 digest =
+            keccak256(LibRLP.encode(unsignedLock(nonce, data).p(block.chainid).p(uint256(0)).p(uint256(0))));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+
+        return LibRLP.encode(unsignedLock(nonce, data).p(block.chainid * 2 + 35 + (v - 27)).p(uint256(r)).p(uint256(s)));
+    }
+
+    function unsignedLock(uint256 nonce, bytes memory data) internal view returns (LibRLP.List memory list) {
+        list = LibRLP.p(nonce).p(uint256(1 gwei)).p(uint256(1_000_000)).p(address(accountsGuard)).p(uint256(0)).p(data);
     }
 }

--- a/test/fuzz/asset-modules/AbstractAM/Constructor.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractAM/Constructor.fuzz.t.sol
@@ -24,7 +24,7 @@ contract Constructor_AbstractAM_Fuzz_Test is AbstractAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_deployment(address registry_, uint256 assetType_) public {
-        vm.assume(assetType_ > 0);
+        assetType_ = bound(assetType_, 1, type(uint256).max);
 
         vm.startPrank(users.owner);
         AssetModuleMock assetModule_ = new AssetModuleMock(users.owner, registry_, assetType_);

--- a/test/fuzz/asset-modules/AbstractAM/Constructor.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractAM/Constructor.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { AbstractAM_Fuzz_Test } from "./_AbstractAM.fuzz.t.sol";
-
 import { AssetModuleMock } from "../../../utils/mocks/asset-modules/AssetModuleMock.sol";
 
 /**

--- a/test/fuzz/asset-modules/AbstractDerivedAM/Constructor.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/Constructor.fuzz.t.sol
@@ -24,7 +24,7 @@ contract Constructor_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test 
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_deployment(address registry_, uint256 assetType_) public {
-        vm.assume(assetType_ > 0);
+        assetType_ = bound(assetType_, 1, type(uint256).max);
 
         vm.startPrank(users.owner);
         DerivedAMMock assetModule_ = new DerivedAMMock(users.owner, registry_, assetType_);

--- a/test/fuzz/asset-modules/AbstractDerivedAM/Constructor.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/Constructor.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
-
 import { DerivedAMMock } from "../../../utils/mocks/asset-modules/DerivedAMMock.sol";
 
 /**

--- a/test/fuzz/asset-modules/AbstractDerivedAM/GetRateUnderlyingAssetsToUsd.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/GetRateUnderlyingAssetsToUsd.fuzz.t.sol
@@ -11,7 +11,7 @@ import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuati
 /**
  * @notice Fuzz tests for the function "_getRateUnderlyingAssetsToUsd" of contract "AbstractDerivedAM".
  */
-// forge-lint: disable-next-item(mixed-case-variable)
+// forge-lint: disable-next-item(mixed-case-variable,unsafe-typecast)
 contract GetRateUnderlyingAssetsToUsd_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -32,13 +32,16 @@ contract GetRateUnderlyingAssetsToUsd_AbstractDerivedAM_Fuzz_Test is AbstractDer
         assetState.assetId = bound(assetState.assetId, 0, type(uint96).max);
         assetState.underlyingAssetId = bound(assetState.underlyingAssetId, 0, type(uint96).max);
 
+        // And: The asset price does not overflow.
+        underlyingPMState.assetUnit = uint64(bound(underlyingPMState.assetUnit, 1, type(uint64).max));
+        underlyingPMState.rateInUsd = bound(underlyingPMState.rateInUsd, 0, type(uint256).max / 1e18);
+
         // And: State is persisted.
         setDerivedAMAssetState(assetState);
         setUnderlyingAssetModuleState(assetState, underlyingPMState);
 
         // Prepare input.
         bytes32[] memory underlyingAssetKeys = new bytes32[](1);
-        // forge-lint: disable-next-item(unsafe-typecast)
         underlyingAssetKeys[0] =
             bytes32(abi.encodePacked(uint96(assetState.underlyingAssetId), assetState.underlyingAsset));
 
@@ -59,6 +62,8 @@ contract GetRateUnderlyingAssetsToUsd_AbstractDerivedAM_Fuzz_Test is AbstractDer
             derivedAM.getRateUnderlyingAssetsToUsd(assetState.creditor, underlyingAssetKeys);
 
         // And: Transaction returns correct "rateUnderlyingAssetsToUsd".
-        assertEq(rateUnderlyingAssetsToUsd[0].assetValue, underlyingPMState.usdValue);
+        assertEq(
+            rateUnderlyingAssetsToUsd[0].assetValue, 1e18 * underlyingPMState.rateInUsd / underlyingPMState.assetUnit
+        );
     }
 }

--- a/test/fuzz/asset-modules/AbstractDerivedAM/GetRateUnderlyingAssetsToUsd.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/GetRateUnderlyingAssetsToUsd.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
-
 import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
 
 /**

--- a/test/fuzz/asset-modules/AbstractDerivedAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/GetRiskFactors.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
-
 import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.sol";
 import { Utils } from "../../../utils/Utils.sol";
 

--- a/test/fuzz/asset-modules/AbstractDerivedAM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/GetValue.fuzz.t.sol
@@ -9,7 +9,7 @@ import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "getValue" of contract "AbstractDerivedAM".
  */
-// forge-lint: disable-next-item(mixed-case-variable)
+// forge-lint: disable-next-item(divide-before-multiply,mixed-case-variable,unsafe-typecast)
 contract GetValue_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -60,9 +60,12 @@ contract GetValue_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
         assetState.underlyingAssetId = bound(assetState.underlyingAssetId, 0, type(uint96).max);
 
         // And: valueInUsd does not overflow.
-        if (assetState.exposureAssetToUnderlyingAsset > 0) {
-            underlyingPMState.usdValue =
-                bound(underlyingPMState.usdValue, 0, type(uint256).max / assetState.exposureAssetToUnderlyingAsset);
+        underlyingPMState.assetUnit = uint64(bound(underlyingPMState.assetUnit, 1, type(uint64).max));
+        underlyingPMState.rateInUsd = bound(underlyingPMState.rateInUsd, 0, type(uint256).max / 1e18);
+        uint256 rateUnderlyingAssetToUsd = 1e18 * underlyingPMState.rateInUsd / underlyingPMState.assetUnit;
+        if (rateUnderlyingAssetToUsd > 0) {
+            assetState.exposureAssetToUnderlyingAsset =
+                bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint256).max / rateUnderlyingAssetToUsd);
         }
 
         // And: State is persisted.
@@ -86,7 +89,7 @@ contract GetValue_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Test {
             derivedAM.getValue(assetState.creditor, assetState.asset, assetState.assetId, amount);
 
         // And: Transaction returns correct "valueInUsd".
-        uint256 expectedValueInUsd = underlyingPMState.usdValue * assetState.exposureAssetToUnderlyingAsset / 1e18;
+        uint256 expectedValueInUsd = rateUnderlyingAssetToUsd * assetState.exposureAssetToUnderlyingAsset / 1e18;
         assertEq(actualValueInUsd, expectedValueInUsd);
     }
 }

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
@@ -5,6 +5,7 @@
 pragma solidity ^0.8.0;
 
 import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { AssetModule } from "../../../../src/asset-modules/abstracts/AbstractAM.sol";
 
 /**
@@ -32,24 +33,20 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: "exposure" of underlyingAsset is strictly smaller than its "maxExposure".
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max - 1);
-
         // And: delta "usdExposureAsset" is positive (test-case).
-        underlyingPMState.usdValue =
-            bound(underlyingPMState.usdValue, assetState.lastUsdExposureAsset, type(uint112).max);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset = uint112(bound(assetState.lastUsdExposureAsset, 0, usdValue));
 
         // And: "usdExposureProtocol" does not overflow (unrealistically big).
         protocolState.lastUsdExposureProtocol = uint112(
             bound(
                 protocolState.lastUsdExposureProtocol,
                 assetState.lastUsdExposureAsset,
-                type(uint112).max - (underlyingPMState.usdValue - assetState.lastUsdExposureAsset)
+                type(uint112).max - (usdValue - assetState.lastUsdExposureAsset)
             )
         );
         uint256 usdExposureProtocolExpected =
-            protocolState.lastUsdExposureProtocol + (underlyingPMState.usdValue - assetState.lastUsdExposureAsset);
+            protocolState.lastUsdExposureProtocol + (usdValue - assetState.lastUsdExposureAsset);
 
         // And: exposure exceeds max exposure.
         vm.assume(usdExposureProtocolExpected > 0);
@@ -77,18 +74,15 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: "exposure" of underlyingAsset is strictly smaller than its "maxExposure".
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max - 1);
-
         // And: delta "usdExposureAsset" is negative (test-case).
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 0, assetState.lastUsdExposureAsset);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset = uint112(bound(assetState.lastUsdExposureAsset, usdValue, type(uint112).max));
 
         // And: "exposure" is equal or bigger than "maxExposure".
         uint256 usdExposureProtocolExpected;
-        if (protocolState.lastUsdExposureProtocol > assetState.lastUsdExposureAsset - underlyingPMState.usdValue) {
+        if (protocolState.lastUsdExposureProtocol > assetState.lastUsdExposureAsset - usdValue) {
             usdExposureProtocolExpected =
-                protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - underlyingPMState.usdValue);
+                protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - usdValue);
         }
         protocolState.maxUsdExposureProtocol =
             uint112(bound(protocolState.maxUsdExposureProtocol, 0, usdExposureProtocolExpected));
@@ -114,24 +108,20 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: "exposure" of underlyingAsset is strictly smaller than its "maxExposure".
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max - 1);
-
         // And: delta "usdExposureAsset" is positive (test-case).
-        underlyingPMState.usdValue =
-            bound(underlyingPMState.usdValue, assetState.lastUsdExposureAsset, type(uint112).max);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset = uint112(bound(assetState.lastUsdExposureAsset, 0, usdValue));
 
         // And: "usdExposureProtocol" does not overflow (unrealistically big).
         protocolState.lastUsdExposureProtocol = uint112(
             bound(
                 protocolState.lastUsdExposureProtocol,
                 assetState.lastUsdExposureAsset,
-                type(uint112).max - (underlyingPMState.usdValue - assetState.lastUsdExposureAsset)
+                type(uint112).max - (usdValue - assetState.lastUsdExposureAsset)
             )
         );
         uint256 usdExposureProtocolExpected =
-            protocolState.lastUsdExposureProtocol + (underlyingPMState.usdValue - assetState.lastUsdExposureAsset);
+            protocolState.lastUsdExposureProtocol + (usdValue - assetState.lastUsdExposureAsset);
 
         // And: "exposure" is strictly smaller than "maxExposure" (test-case).
         vm.assume(usdExposureProtocolExpected < type(uint112).max);
@@ -164,7 +154,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         uint256 usdExposureAsset = derivedAM.processDeposit(assetState.creditor, assetKey, exposureAsset);
 
         // And: Transaction returns correct "usdExposureAsset".
-        assertEq(usdExposureAsset, underlyingPMState.usdValue);
+        assertEq(usdExposureAsset, usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
         assertEq(
@@ -174,7 +164,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
 
         // And: "lastUsdExposureAsset" is updated.
         (, uint256 lastUsdExposureAsset) = derivedAM.getAssetExposureLast(assetState.creditor, assetKey);
-        assertEq(lastUsdExposureAsset, underlyingPMState.usdValue);
+        assertEq(lastUsdExposureAsset, usdValue);
 
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
@@ -190,24 +180,17 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: "exposure" of underlyingAsset is strictly smaller than its "maxExposure".
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max - 1);
-
         // And: delta "usdExposureAsset" is negative (test-case).
-        assetState.lastUsdExposureAsset = uint112(bound(assetState.lastUsdExposureAsset, 1, type(uint112).max));
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 0, assetState.lastUsdExposureAsset - 1);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset =
+            uint112(bound(assetState.lastUsdExposureAsset, usdValue + 1, type(uint112).max));
 
         // And: "usdExposureProtocol" does not underflow (test-case).
         protocolState.lastUsdExposureProtocol = uint112(
-            bound(
-                protocolState.lastUsdExposureProtocol,
-                assetState.lastUsdExposureAsset - underlyingPMState.usdValue,
-                type(uint112).max
-            )
+            bound(protocolState.lastUsdExposureProtocol, assetState.lastUsdExposureAsset - usdValue, type(uint112).max)
         );
         uint256 usdExposureProtocolExpected =
-            protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - underlyingPMState.usdValue);
+            protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - usdValue);
 
         // And: "exposure" is strictly smaller than "maxExposure" (test-case).
         vm.assume(usdExposureProtocolExpected < type(uint112).max);
@@ -240,7 +223,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         uint256 usdExposureAsset = derivedAM.processDeposit(assetState.creditor, assetKey, exposureAsset);
 
         // Then: Transaction returns correct "usdExposureAsset".
-        assertEq(usdExposureAsset, underlyingPMState.usdValue);
+        assertEq(usdExposureAsset, usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
         assertEq(
@@ -250,7 +233,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
 
         // And: "lastUsdExposureAsset" is updated.
         (, uint256 lastUsdExposureAsset) = derivedAM.getAssetExposureLast(assetState.creditor, assetKey);
-        assertEq(lastUsdExposureAsset, underlyingPMState.usdValue);
+        assertEq(lastUsdExposureAsset, usdValue);
 
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
@@ -266,20 +249,14 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: "exposure" of underlyingAsset is strictly smaller than its "maxExposure".
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max - 1);
-
         // And: delta "usdExposureAsset" is negative (test-case).
-        vm.assume(assetState.lastUsdExposureAsset > 0);
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 0, assetState.lastUsdExposureAsset - 1);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset =
+            uint112(bound(assetState.lastUsdExposureAsset, usdValue + 1, type(uint112).max));
 
         // And: "usdExposureProtocol" does underflow (test-case).
-        protocolState.lastUsdExposureProtocol = uint112(
-            bound(
-                protocolState.lastUsdExposureProtocol, 0, assetState.lastUsdExposureAsset - underlyingPMState.usdValue
-            )
-        );
+        protocolState.lastUsdExposureProtocol =
+            uint112(bound(protocolState.lastUsdExposureProtocol, 0, assetState.lastUsdExposureAsset - usdValue));
 
         // And: "exposure" is strictly smaller than "maxExposure" (test-case).
         protocolState.maxUsdExposureProtocol =
@@ -311,7 +288,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         uint256 usdExposureAsset = derivedAM.processDeposit(assetState.creditor, assetKey, exposureAsset);
 
         // Then: Transaction returns correct "usdExposureAsset".
-        assertEq(usdExposureAsset, underlyingPMState.usdValue);
+        assertEq(usdExposureAsset, usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
         assertEq(
@@ -321,7 +298,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
 
         // And: "lastUsdExposureAsset" is updated.
         (, uint256 lastUsdExposureAsset) = derivedAM.getAssetExposureLast(assetState.creditor, assetKey);
-        assertEq(lastUsdExposureAsset, underlyingPMState.usdValue);
+        assertEq(lastUsdExposureAsset, usdValue);
 
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
@@ -369,6 +346,18 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         registry.setAssetModule(underlyingAssetB, address(primaryAM));
         primaryAM.setExposure(creditor, underlyingAssetA, 0, 0, type(uint112).max);
         primaryAM.setExposure(creditor, underlyingAssetB, 0, 0, type(uint112).max);
+
+        // And: Both underlying assets are priced, the values themselves are not asserted here.
+        {
+            addMockedOracle(PRIMARY_AM_ORACLE_ID, 0, bytes16("A"), bytes16("USD"), true);
+            uint80[] memory oracleIds = new uint80[](1);
+            oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+            bool[] memory baseToQuoteAsset = new bool[](1);
+            baseToQuoteAsset[0] = true;
+            bytes32 sequence = BitPackingLib.pack(baseToQuoteAsset, oracleIds);
+            primaryAM.setAssetInformation(underlyingAssetA, 0, 1, sequence);
+            primaryAM.setAssetInformation(underlyingAssetB, 0, 1, sequence);
+        }
 
         // When: "_processDeposit" is called.
         bytes32 assetKey = derivedAM.getKeyFromAsset(asset, assetId);

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
@@ -342,7 +342,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         primaryAM.setExposure(creditor, underlyingAssetA, 0, 0, type(uint112).max);
         primaryAM.setExposure(creditor, underlyingAssetB, 0, 0, type(uint112).max);
 
-        // And: Both underlying assets are priced, the values themselves are not asserted here.
+        // And: Both underlying assets are priced.
         {
             addMockedOracle(PRIMARY_AM_ORACLE_ID, 0, bytes16("A"), bytes16("USD"), true);
             uint80[] memory oracleIds = new uint80[](1);

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDeposit.fuzz.t.sol
@@ -41,7 +41,7 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
         protocolState.lastUsdExposureProtocol = uint112(
             bound(
                 protocolState.lastUsdExposureProtocol,
-                assetState.lastUsdExposureAsset,
+                assetState.lastUsdExposureAsset == 0 ? 1 : assetState.lastUsdExposureAsset,
                 type(uint112).max - (usdValue - assetState.lastUsdExposureAsset)
             )
         );
@@ -49,7 +49,6 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
             protocolState.lastUsdExposureProtocol + (usdValue - assetState.lastUsdExposureAsset);
 
         // And: exposure exceeds max exposure.
-        vm.assume(usdExposureProtocolExpected > 0);
         protocolState.maxUsdExposureProtocol =
             uint112(bound(protocolState.maxUsdExposureProtocol, 0, usdExposureProtocolExpected - 1));
 
@@ -117,14 +116,11 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
             bound(
                 protocolState.lastUsdExposureProtocol,
                 assetState.lastUsdExposureAsset,
-                type(uint112).max - (usdValue - assetState.lastUsdExposureAsset)
+                type(uint112).max - (usdValue - assetState.lastUsdExposureAsset) - 1
             )
         );
         uint256 usdExposureProtocolExpected =
             protocolState.lastUsdExposureProtocol + (usdValue - assetState.lastUsdExposureAsset);
-
-        // And: "exposure" is strictly smaller than "maxExposure" (test-case).
-        vm.assume(usdExposureProtocolExpected < type(uint112).max);
         protocolState.maxUsdExposureProtocol =
             uint112(bound(protocolState.maxUsdExposureProtocol, usdExposureProtocolExpected + 1, type(uint112).max));
 
@@ -193,7 +189,6 @@ contract ProcessDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz_Te
             protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - usdValue);
 
         // And: "exposure" is strictly smaller than "maxExposure" (test-case).
-        vm.assume(usdExposureProtocolExpected < type(uint112).max);
         protocolState.maxUsdExposureProtocol =
             uint112(bound(protocolState.maxUsdExposureProtocol, usdExposureProtocolExpected + 1, type(uint112).max));
 

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDirectDeposit.fuzz.t.sol
@@ -45,7 +45,7 @@ contract ProcessDirectDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_F
         int256 amount
     ) public {
         // And: No overflow on negation most negative int256 (this overflows).
-        vm.assume(amount > type(int256).min);
+        amount = bound(amount, type(int256).min + 1, type(int256).max);
         amount = amount >= 0 ? amount : -amount;
 
         // And: Deposit does not revert.

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessDirectWithdrawal.fuzz.t.sol
@@ -45,7 +45,7 @@ contract ProcessDirectWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedA
         int256 amount
     ) public {
         // And: No overflow on negation most negative int256 (this overflows).
-        vm.assume(amount > type(int256).min);
+        amount = bound(amount, type(int256).min + 1, type(int256).max);
         amount = amount >= 0 ? -amount : amount;
 
         // And: Withdrawal does not revert.

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessIndirectDeposit.fuzz.t.sol
@@ -87,7 +87,7 @@ contract ProcessIndirectDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM
         int256 deltaExposureUpperAssetToAsset
     ) public {
         // Given: "usdExposureAsset" is 0 (test-case).
-        underlyingPMState.usdValue = 0;
+        underlyingPMState.rateInUsd = 0;
 
         // And: Deposit does not revert.
         (protocolState, assetState, underlyingPMState, exposureUpperAssetToAsset, deltaExposureUpperAssetToAsset) =
@@ -124,14 +124,15 @@ contract ProcessIndirectDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM
         uint256 exposureUpperAssetToAsset,
         int256 deltaExposureUpperAssetToAsset
     ) public {
-        // Given: "usdExposureToUnderlyingAsset" is not zero (test-case).
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 1, type(uint112).max);
-
-        // And: Deposit does not revert.
+        // Given: Deposit does not revert.
         (protocolState, assetState, underlyingPMState, exposureUpperAssetToAsset, deltaExposureUpperAssetToAsset) =
             givenNonRevertingDeposit(
                 protocolState, assetState, underlyingPMState, exposureUpperAssetToAsset, deltaExposureUpperAssetToAsset
             );
+
+        // And: "usdExposureToUnderlyingAsset" is not zero (test-case).
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        vm.assume(usdValue > 0);
 
         // And: exposureAsset is not zero (test-case).
         uint256 exposureAsset;
@@ -162,8 +163,7 @@ contract ProcessIndirectDeposit_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM
         assertEq(recursiveCalls, 2);
 
         // And: Correct "usdExposureUpperAssetToAsset" is returned.
-        uint256 usdExposureUpperAssetToAssetExpected =
-            underlyingPMState.usdValue * exposureUpperAssetToAsset / exposureAsset;
+        uint256 usdExposureUpperAssetToAssetExpected = usdValue * exposureUpperAssetToAsset / exposureAsset;
         assertEq(usdExposureUpperAssetToAsset, usdExposureUpperAssetToAssetExpected);
     }
 }

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -86,7 +86,7 @@ contract ProcessIndirectWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerive
         int256 deltaExposureUpperAssetToAsset
     ) public {
         // Given: "usdExposureAsset" is 0 (test-case).
-        underlyingPMState.usdValue = 0;
+        underlyingPMState.rateInUsd = 0;
 
         // And: Withdrawal does not revert.
         (protocolState, assetState, underlyingPMState, exposureUpperAssetToAsset, deltaExposureUpperAssetToAsset) =
@@ -120,14 +120,15 @@ contract ProcessIndirectWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerive
         uint256 exposureUpperAssetToAsset,
         int256 deltaExposureUpperAssetToAsset
     ) public {
-        // Given: "usdExposureToUnderlyingAsset" is not zero (test-case).
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 1, type(uint112).max);
-
-        // And: Withdrawal does not revert.
+        // Given: Withdrawal does not revert.
         (protocolState, assetState, underlyingPMState, exposureUpperAssetToAsset, deltaExposureUpperAssetToAsset) =
             givenNonRevertingWithdrawal(
                 protocolState, assetState, underlyingPMState, exposureUpperAssetToAsset, deltaExposureUpperAssetToAsset
             );
+
+        // And: "usdExposureToUnderlyingAsset" is not zero (test-case).
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        vm.assume(usdValue > 0);
 
         // And: exposureAsset is not zero (test-case).
         uint256 exposureAsset;
@@ -155,8 +156,7 @@ contract ProcessIndirectWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerive
         );
 
         // And: Correct "usdExposureUpperAssetToAsset" is returned.
-        uint256 usdExposureUpperAssetToAssetExpected =
-            underlyingPMState.usdValue * exposureUpperAssetToAsset / exposureAsset;
+        uint256 usdExposureUpperAssetToAssetExpected = usdValue * exposureUpperAssetToAsset / exposureAsset;
         assertEq(usdExposureUpperAssetToAsset, usdExposureUpperAssetToAssetExpected);
     }
 }

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
@@ -5,6 +5,7 @@
 pragma solidity ^0.8.0;
 
 import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 
 /**
  * @notice Fuzz tests for the function "_processWithdrawal" of contract "AbstractDerivedAM".
@@ -31,20 +32,16 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: No overflow on exposureAssetToUnderlyingAsset.
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max);
-
         // And: delta "usdExposureAsset" is positive (test-case).
-        vm.assume(assetState.lastUsdExposureAsset < type(uint112).max);
-        underlyingPMState.usdValue =
-            bound(underlyingPMState.usdValue, assetState.lastUsdExposureAsset + 1, type(uint112).max);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        vm.assume(usdValue > 0);
+        assetState.lastUsdExposureAsset = uint112(bound(assetState.lastUsdExposureAsset, 0, usdValue - 1));
 
         // And: "usdExposureProtocol" overflows (unrealistically big).
         protocolState.lastUsdExposureProtocol = uint112(
             bound(
                 protocolState.lastUsdExposureProtocol,
-                type(uint112).max - (underlyingPMState.usdValue - assetState.lastUsdExposureAsset) + 1,
+                type(uint112).max - (usdValue - assetState.lastUsdExposureAsset) + 1,
                 type(uint112).max
             )
         );
@@ -71,24 +68,20 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: No overflow on exposureAssetToUnderlyingAsset.
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max);
-
         // And: delta "usdExposureAsset" is positive (test-case).
-        underlyingPMState.usdValue =
-            bound(underlyingPMState.usdValue, assetState.lastUsdExposureAsset, type(uint112).max);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset = uint112(bound(assetState.lastUsdExposureAsset, 0, usdValue));
 
         // And: "usdExposureProtocol" does not overflow (unrealistically big).
         protocolState.lastUsdExposureProtocol = uint112(
             bound(
                 protocolState.lastUsdExposureProtocol,
                 assetState.lastUsdExposureAsset,
-                type(uint112).max - (underlyingPMState.usdValue - assetState.lastUsdExposureAsset)
+                type(uint112).max - (usdValue - assetState.lastUsdExposureAsset)
             )
         );
         uint256 usdExposureProtocolExpected =
-            protocolState.lastUsdExposureProtocol + (underlyingPMState.usdValue - assetState.lastUsdExposureAsset);
+            protocolState.lastUsdExposureProtocol + (usdValue - assetState.lastUsdExposureAsset);
 
         // And: exposure does not exceeds max exposure.
         protocolState.maxUsdExposureProtocol =
@@ -120,7 +113,7 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         uint256 usdExposureAsset = derivedAM.processWithdrawal(assetState.creditor, assetKey, exposureAsset);
 
         // Then: Transaction returns correct "usdExposureAsset".
-        assertEq(usdExposureAsset, underlyingPMState.usdValue);
+        assertEq(usdExposureAsset, usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
         assertEq(
@@ -130,7 +123,7 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
 
         // And: "lastUsdExposureAsset" is updated.
         (, uint256 lastUsdExposureAsset) = derivedAM.getAssetExposureLast(assetState.creditor, assetKey);
-        assertEq(lastUsdExposureAsset, underlyingPMState.usdValue);
+        assertEq(lastUsdExposureAsset, usdValue);
 
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
@@ -146,24 +139,17 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: No overflow on exposureAssetToUnderlyingAsset.
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max);
-
         // And: delta "usdExposureAsset" is negative (test-case).
-        vm.assume(assetState.lastUsdExposureAsset > 0);
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 0, assetState.lastUsdExposureAsset - 1);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset =
+            uint112(bound(assetState.lastUsdExposureAsset, usdValue + 1, type(uint112).max));
 
         // And: "usdExposureProtocol" does not underflow (test-case).
         protocolState.lastUsdExposureProtocol = uint112(
-            bound(
-                protocolState.lastUsdExposureProtocol,
-                assetState.lastUsdExposureAsset - underlyingPMState.usdValue,
-                type(uint112).max
-            )
+            bound(protocolState.lastUsdExposureProtocol, assetState.lastUsdExposureAsset - usdValue, type(uint112).max)
         );
         uint256 usdExposureProtocolExpected =
-            protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - underlyingPMState.usdValue);
+            protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - usdValue);
 
         // And: State is persisted.
         setDerivedAMProtocolState(protocolState, assetState.creditor);
@@ -191,7 +177,7 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         uint256 usdExposureAsset = derivedAM.processWithdrawal(assetState.creditor, assetKey, exposureAsset);
 
         // Then: Transaction returns correct "usdExposureAsset".
-        assertEq(usdExposureAsset, underlyingPMState.usdValue);
+        assertEq(usdExposureAsset, usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
         assertEq(
@@ -201,7 +187,7 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
 
         // And: "lastUsdExposureAsset" is updated.
         (, uint256 lastUsdExposureAsset) = derivedAM.getAssetExposureLast(assetState.creditor, assetKey);
-        assertEq(lastUsdExposureAsset, underlyingPMState.usdValue);
+        assertEq(lastUsdExposureAsset, usdValue);
 
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
@@ -217,20 +203,14 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         // Given: valid initial state.
         (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
 
-        // And: No overflow on exposureAssetToUnderlyingAsset.
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max);
-
         // And: delta "usdExposureAsset" is negative (test-case).
-        vm.assume(assetState.lastUsdExposureAsset > 0);
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 0, assetState.lastUsdExposureAsset - 1);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
+        assetState.lastUsdExposureAsset =
+            uint112(bound(assetState.lastUsdExposureAsset, usdValue + 1, type(uint112).max));
 
         // And: "usdExposureProtocol" does underflow (test-case).
-        protocolState.lastUsdExposureProtocol = uint112(
-            bound(
-                protocolState.lastUsdExposureProtocol, 0, assetState.lastUsdExposureAsset - underlyingPMState.usdValue
-            )
-        );
+        protocolState.lastUsdExposureProtocol =
+            uint112(bound(protocolState.lastUsdExposureProtocol, 0, assetState.lastUsdExposureAsset - usdValue));
 
         // And: State is persisted.
         setDerivedAMProtocolState(protocolState, assetState.creditor);
@@ -258,7 +238,7 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         uint256 usdExposureAsset = derivedAM.processWithdrawal(assetState.creditor, assetKey, exposureAsset);
 
         // Then: Transaction returns correct "usdExposureAsset".
-        assertEq(usdExposureAsset, underlyingPMState.usdValue);
+        assertEq(usdExposureAsset, usdValue);
 
         // And: "lastExposureAssetToUnderlyingAsset" is updated.
         assertEq(
@@ -268,7 +248,7 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
 
         // And: "lastUsdExposureAsset" is updated.
         (, uint256 lastUsdExposureAsset) = derivedAM.getAssetExposureLast(assetState.creditor, assetKey);
-        assertEq(lastUsdExposureAsset, underlyingPMState.usdValue);
+        assertEq(lastUsdExposureAsset, usdValue);
 
         // And: "usdExposureProtocol" is updated.
         (uint128 usdExposureProtocolActual,,) = derivedAM.riskParams(assetState.creditor);
@@ -316,6 +296,18 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         registry.setAssetModule(underlyingAssetB, address(primaryAM));
         primaryAM.setExposure(creditor, underlyingAssetA, 0, 0, type(uint112).max);
         primaryAM.setExposure(creditor, underlyingAssetB, 0, 0, type(uint112).max);
+
+        // And: Both underlying assets are priced, the values themselves are not asserted here.
+        {
+            addMockedOracle(PRIMARY_AM_ORACLE_ID, 0, bytes16("A"), bytes16("USD"), true);
+            uint80[] memory oracleIds = new uint80[](1);
+            oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+            bool[] memory baseToQuoteAsset = new bool[](1);
+            baseToQuoteAsset[0] = true;
+            bytes32 sequence = BitPackingLib.pack(baseToQuoteAsset, oracleIds);
+            primaryAM.setAssetInformation(underlyingAssetA, 0, 1, sequence);
+            primaryAM.setAssetInformation(underlyingAssetB, 0, 1, sequence);
+        }
 
         // And: A deposit of the asset was processed.
         bytes32 assetKey = derivedAM.getKeyFromAsset(asset, assetId);

--- a/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/ProcessWithdrawal.fuzz.t.sol
@@ -297,7 +297,7 @@ contract ProcessWithdrawal_AbstractDerivedAM_Fuzz_Test is AbstractDerivedAM_Fuzz
         primaryAM.setExposure(creditor, underlyingAssetA, 0, 0, type(uint112).max);
         primaryAM.setExposure(creditor, underlyingAssetB, 0, 0, type(uint112).max);
 
-        // And: Both underlying assets are priced, the values themselves are not asserted here.
+        // And: Both underlying assets are priced.
         {
             addMockedOracle(PRIMARY_AM_ORACLE_ID, 0, bytes16("A"), bytes16("USD"), true);
             uint80[] memory oracleIds = new uint80[](1);

--- a/test/fuzz/asset-modules/AbstractDerivedAM/SetRiskParameters.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/SetRiskParameters.fuzz.t.sol
@@ -6,9 +6,8 @@ pragma solidity ^0.8.0;
 
 import { AbstractDerivedAM_Fuzz_Test } from "./_AbstractDerivedAM.fuzz.t.sol";
 import { AssetModule } from "../../../../src/asset-modules/abstracts/AbstractAM.sol";
-
-import { DerivedAM } from "../../../../src/asset-modules/abstracts/AbstractDerivedAM.sol";
 import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.sol";
+import { DerivedAM } from "../../../../src/asset-modules/abstracts/AbstractDerivedAM.sol";
 
 /**
  * @notice Fuzz tests for the function "setRiskParameters" of contract "AbstractDerivedAM".

--- a/test/fuzz/asset-modules/AbstractDerivedAM/_AbstractDerivedAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/_AbstractDerivedAM.fuzz.t.sol
@@ -4,7 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { DerivedAMMock } from "../../../utils/mocks/asset-modules/DerivedAMMock.sol";
+import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
 import { Fuzz_Test } from "../../Fuzz.t.sol";
 import { PrimaryAMMock } from "../../../utils/mocks/asset-modules/PrimaryAMMock.sol";
 
@@ -38,7 +40,8 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
 
     struct UnderlyingAssetModuleState {
         uint112 exposureAssetLast;
-        uint256 usdValue;
+        uint64 assetUnit;
+        uint256 rateInUsd;
     }
 
     /*////////////////////////////////////////////////////////////////
@@ -47,7 +50,10 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
 
     // forge-lint: disable-start(mixed-case-variable)
     DerivedAMMock internal derivedAM;
+    OracleModuleMock internal oracleModule;
     PrimaryAMMock internal primaryAM;
+
+    uint256 internal constant PRIMARY_AM_ORACLE_ID = 999;
     // forge-lint: disable-end(mixed-case-variable)
 
     /* ///////////////////////////////////////////////////////////////
@@ -62,6 +68,7 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
         derivedAM = new DerivedAMMock(users.owner, address(registry), 0);
 
         primaryAM = new PrimaryAMMock(users.owner, address(registry), 0);
+        oracleModule = new OracleModuleMock(users.owner, address(registry));
 
         registry.addAssetModule(address(derivedAM));
         registry.addAssetModule(address(primaryAM));
@@ -106,6 +113,24 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
         );
     }
 
+    function addMockedOracle(uint256 oracleId, uint256 rate, bytes16 baseAsset, bytes16 quoteAsset, bool active)
+        public
+    {
+        oracleModule.setOracle(oracleId, baseAsset, quoteAsset, active);
+        registry.setOracleToOracleModule(oracleId, address(oracleModule));
+        oracleModule.setRate(oracleId, rate);
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
+    function setPrimaryAMOracle(address asset, uint256 assetId, uint64 assetUnit, uint256 usdValue) public {
+        addMockedOracle(PRIMARY_AM_ORACLE_ID, usdValue, bytes16("A"), bytes16("USD"), true);
+        uint80[] memory oracleIds = new uint80[](1);
+        oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+        bool[] memory baseToQuoteAsset = new bool[](1);
+        baseToQuoteAsset[0] = true;
+        primaryAM.setAssetInformation(asset, assetId, assetUnit, BitPackingLib.pack(baseToQuoteAsset, oracleIds));
+    }
+
     // forge-lint: disable-next-item(mixed-case-variable)
     function setUnderlyingAssetModuleState(
         DerivedAMAssetState memory assetState,
@@ -119,8 +144,20 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
             assetState.creditor, assetState.underlyingAsset, assetState.underlyingAssetId, 0, type(uint112).max
         );
 
-        // Mock the "usdValue".
-        primaryAM.setUsdValue(underlyingPMState.usdValue);
+        setPrimaryAMOracle(
+            assetState.underlyingAsset,
+            assetState.underlyingAssetId,
+            underlyingPMState.assetUnit,
+            underlyingPMState.rateInUsd
+        );
+    }
+
+    // forge-lint: disable-next-item(mixed-case-variable)
+    function usdExposureToUnderlyingAsset(
+        DerivedAMAssetState memory assetState,
+        UnderlyingAssetModuleState memory underlyingPMState
+    ) internal pure returns (uint256) {
+        return assetState.exposureAssetToUnderlyingAsset * underlyingPMState.rateInUsd / underlyingPMState.assetUnit;
     }
 
     // forge-lint: disable-next-item(mixed-case-variable)
@@ -136,6 +173,18 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
         // Given: id's are smaller or equal to type(uint96).max.
         assetState.assetId = bound(assetState.assetId, 0, type(uint96).max);
         assetState.underlyingAssetId = bound(assetState.underlyingAssetId, 0, type(uint96).max);
+
+        // And: "exposure" of underlyingAsset is strictly smaller than its "maxExposure".
+        assetState.exposureAssetToUnderlyingAsset =
+            bound(assetState.exposureAssetToUnderlyingAsset, 1, type(uint64).max);
+
+        // And: "usdExposureToUnderlyingAsset" does not overflow.
+        underlyingPMState.assetUnit = uint64(bound(underlyingPMState.assetUnit, 1, type(uint64).max));
+        underlyingPMState.rateInUsd = bound(
+            underlyingPMState.rateInUsd,
+            0,
+            uint256(type(uint112).max - 1) * underlyingPMState.assetUnit / assetState.exposureAssetToUnderlyingAsset
+        );
 
         // And: usd Value of protocol is bigger or equal to each individual usd value of an asset (Invariant).
         assetState.lastUsdExposureAsset =
@@ -162,18 +211,14 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
             int256
         )
     {
-        // Given: "usdExposureToUnderlyingAsset" does not overflow.
-        underlyingPMState.usdValue = bound(underlyingPMState.usdValue, 0, type(uint112).max);
+        // Given: valid initial state.
+        (protocolState, assetState, underlyingPMState) = givenValidState(protocolState, assetState, underlyingPMState);
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
 
         // And: "usdExposureUpperAssetToAsset" does not overflow (unrealistic big values).
-        if (underlyingPMState.usdValue != 0) {
-            exposureUpperAssetToAsset =
-                bound(exposureUpperAssetToAsset, 0, type(uint256).max / underlyingPMState.usdValue);
+        if (usdValue != 0) {
+            exposureUpperAssetToAsset = bound(exposureUpperAssetToAsset, 0, type(uint256).max / usdValue);
         }
-
-        // And: id's are smaller or equal to type(uint96).max.
-        assetState.assetId = bound(assetState.assetId, 0, type(uint96).max);
-        assetState.underlyingAssetId = bound(assetState.underlyingAssetId, 0, type(uint96).max);
 
         // Calculate exposureAsset.
         uint256 exposureAsset;
@@ -193,17 +238,13 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
             }
         }
 
-        // And: "exposure" of underlyingAsset is strictly smaller than its "maxExposure".
-        assetState.exposureAssetToUnderlyingAsset =
-            bound(assetState.exposureAssetToUnderlyingAsset, 0, type(uint112).max - 1);
-
-        if (underlyingPMState.usdValue >= assetState.lastUsdExposureAsset) {
+        if (usdValue >= assetState.lastUsdExposureAsset) {
             // And: "usdExposureProtocol" does not overflow (unrealistically big).
             protocolState.lastUsdExposureProtocol = uint112(
                 bound(
                     protocolState.lastUsdExposureProtocol,
                     assetState.lastUsdExposureAsset,
-                    type(uint112).max - (underlyingPMState.usdValue - assetState.lastUsdExposureAsset)
+                    type(uint112).max - (usdValue - assetState.lastUsdExposureAsset)
                 )
             );
         }
@@ -236,14 +277,15 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
             );
 
         // And: "exposure" is strictly smaller than "maxExposure".
+        uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
         uint256 usdExposureProtocolExpected;
-        if (underlyingPMState.usdValue >= assetState.lastUsdExposureAsset) {
+        if (usdValue >= assetState.lastUsdExposureAsset) {
             usdExposureProtocolExpected =
-                protocolState.lastUsdExposureProtocol + (underlyingPMState.usdValue - assetState.lastUsdExposureAsset);
+                protocolState.lastUsdExposureProtocol + (usdValue - assetState.lastUsdExposureAsset);
         } else {
             usdExposureProtocolExpected = protocolState.lastUsdExposureProtocol
-                > assetState.lastUsdExposureAsset - underlyingPMState.usdValue
-                ? protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - underlyingPMState.usdValue)
+                > assetState.lastUsdExposureAsset - usdValue
+                ? protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - usdValue)
                 : 0;
         }
         vm.assume(usdExposureProtocolExpected < type(uint112).max);

--- a/test/fuzz/asset-modules/AbstractDerivedAM/_AbstractDerivedAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractDerivedAM/_AbstractDerivedAM.fuzz.t.sol
@@ -231,7 +231,8 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
             exposureAsset = assetState.exposureAssetLast + uint256(deltaExposureUpperAssetToAsset);
         } else {
             // And: No overflow on negation most negative int256 (this overflows).
-            vm.assume(deltaExposureUpperAssetToAsset > type(int256).min);
+            deltaExposureUpperAssetToAsset =
+                bound(deltaExposureUpperAssetToAsset, type(int256).min + 1, type(int256).max);
 
             if (uint256(-deltaExposureUpperAssetToAsset) < assetState.exposureAssetLast) {
                 exposureAsset = uint256(assetState.exposureAssetLast) - uint256(-deltaExposureUpperAssetToAsset);
@@ -280,6 +281,14 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
         uint256 usdValue = usdExposureToUnderlyingAsset(assetState, underlyingPMState);
         uint256 usdExposureProtocolExpected;
         if (usdValue >= assetState.lastUsdExposureAsset) {
+            // Leave room for the added exposure, the invariant on lastUsdExposureAsset still holds.
+            protocolState.lastUsdExposureProtocol = uint112(
+                bound(
+                    protocolState.lastUsdExposureProtocol,
+                    assetState.lastUsdExposureAsset,
+                    type(uint112).max - (usdValue - assetState.lastUsdExposureAsset) - 1
+                )
+            );
             usdExposureProtocolExpected =
                 protocolState.lastUsdExposureProtocol + (usdValue - assetState.lastUsdExposureAsset);
         } else {
@@ -288,7 +297,6 @@ abstract contract AbstractDerivedAM_Fuzz_Test is Fuzz_Test {
                 ? protocolState.lastUsdExposureProtocol - (assetState.lastUsdExposureAsset - usdValue)
                 : 0;
         }
-        vm.assume(usdExposureProtocolExpected < type(uint112).max);
         protocolState.maxUsdExposureProtocol =
             uint112(bound(protocolState.maxUsdExposureProtocol, usdExposureProtocolExpected + 1, type(uint112).max));
 

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/Constructor.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/Constructor.fuzz.t.sol
@@ -24,7 +24,7 @@ contract Constructor_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fuzz_Test 
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_deployment(address registry_, uint256 assetType_) public {
-        vm.assume(assetType_ > 0);
+        assetType_ = bound(assetType_, 1, type(uint256).max);
 
         vm.startPrank(users.owner);
         PrimaryAMMock assetModule_ = new PrimaryAMMock(users.owner, registry_, assetType_);

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/Constructor.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/Constructor.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { AbstractPrimaryAM_Fuzz_Test } from "./_AbstractPrimaryAM.fuzz.t.sol";
-
 import { PrimaryAMMock } from "../../../utils/mocks/asset-modules/PrimaryAMMock.sol";
 
 /**

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/GetValue.fuzz.t.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.0;
 import { AbstractPrimaryAM_Fuzz_Test } from "./_AbstractPrimaryAM.fuzz.t.sol";
 
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
-import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
 
 /**
  * @notice Fuzz tests for the function "getValue" of contract "AbstractPrimaryAM".
@@ -20,8 +19,6 @@ contract GetValue_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fuzz_Test {
 
     function setUp() public override {
         AbstractPrimaryAM_Fuzz_Test.setUp();
-
-        oracleModule = new OracleModuleMock(users.owner, address(registry));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -54,9 +51,6 @@ contract GetValue_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fuzz_Test {
         decimals = bound(decimals, 0, 18);
         assetModule.setAssetInformation(asset, assetId, uint64(10 ** decimals), oracleSequence);
 
-        // Use actual getValue() and not the hard-coded value ToDo: refactor
-        assetModule.setUseRealUsdValue(true);
-
         vm.expectRevert(bytes(""));
         assetModule.getValue(creditor, asset, assetId, amount);
     }
@@ -87,9 +81,6 @@ contract GetValue_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fuzz_Test {
         bytes32 oracleSequence = BitPackingLib.pack(baseToQuoteAsset, oraclesIds);
         decimals = bound(decimals, 0, 18);
         assetModule.setAssetInformation(asset, assetId, uint64(10 ** decimals), oracleSequence);
-
-        // Use actual getValue() and not the hard-coded value ToDo: refactor
-        assetModule.setUseRealUsdValue(true);
 
         uint256 expectedValueInUsd = rate * amount / 10 ** decimals;
 

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/GetValue.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { AbstractPrimaryAM_Fuzz_Test } from "./_AbstractPrimaryAM.fuzz.t.sol";
-
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 
 /**

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectDeposit.fuzz.t.sol
@@ -28,7 +28,7 @@ contract ProcessDirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_F
         address unprivilegedAddress_,
         uint256 amount
     ) public {
-        // Given "caller" is not the Registry.
+        // Given: "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
         // And: The value of the exposure does not overflow.

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectDeposit.fuzz.t.sol
@@ -31,6 +31,10 @@ contract ProcessDirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_F
         // Given "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -52,6 +56,10 @@ contract ProcessDirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_F
         // And: "exposureAsset" is bigger or equal as "exposureAssetMax" (test-case).
         assetState.exposureAssetMax = uint112(bound(assetState.exposureAssetMax, 0, expectedExposure));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -70,6 +78,10 @@ contract ProcessDirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_F
         uint256 expectedExposure = assetState.exposureAssetLast + amount;
         assetState.exposureAssetMax =
             uint112(bound(assetState.exposureAssetMax, expectedExposure + 1, type(uint112).max));
+
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
 
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectWithdrawal.fuzz.t.sol
@@ -31,6 +31,10 @@ contract ProcessDirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryA
         // Given "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -47,6 +51,10 @@ contract ProcessDirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryA
     {
         // Given: exposure does not underflow after withdrawal (test-case).
         amount = bound(amount, 0, assetState.exposureAssetLast);
+
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
 
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
@@ -69,6 +77,10 @@ contract ProcessDirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryA
     ) public {
         // Given: exposure does underflow after withdrawal (test-case).
         amount = bound(amount, assetState.exposureAssetLast, type(uint256).max);
+
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
 
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessDirectWithdrawal.fuzz.t.sol
@@ -28,7 +28,7 @@ contract ProcessDirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryA
         address unprivilegedAddress_,
         uint128 amount
     ) public {
-        // Given "caller" is not the Registry.
+        // Given: "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
         // And: The value of the exposure does not overflow.

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectDeposit.fuzz.t.sol
@@ -29,7 +29,7 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
         uint256 exposureUpperAssetToAsset,
         int256 deltaExposureUpperAssetToAsset
     ) public {
-        // Given "caller" is not the Registry.
+        // Given: "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
         // And: The value of the exposure does not overflow.

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectDeposit.fuzz.t.sol
@@ -32,6 +32,15 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
         // Given "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -63,6 +72,15 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
         // And: "exposureAsset" is bigger or equal as "exposureAssetMax" (test-case).
         assetState.exposureAssetMax = uint112(bound(assetState.exposureAssetMax, 0, expectedExposure));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -91,6 +109,15 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
             expectedExposure = assetState.exposureAssetLast - deltaExposureUpperAssetToAsset;
         }
         assetState.exposureAssetMax = uint112(bound(assetState.exposureAssetMax, 0, expectedExposure));
+
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
 
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
@@ -122,6 +149,15 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
         assetState.exposureAssetMax =
             uint112(bound(assetState.exposureAssetMax, expectedExposure + 1, type(uint112).max));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -137,7 +173,7 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
 
         // Then: Correct output variables are returned.
         assertEq(recursiveCalls, 1);
-        assertEq(usdExposureUpperAssetToAsset, assetState.usdExposureUpperAssetToAsset);
+        assertEq(usdExposureUpperAssetToAsset, exposureUpperAssetToAsset * assetState.rateInUsd / assetState.assetUnit);
 
         // And: assetExposure is updated.
         bytes32 assetKey = bytes32(abi.encodePacked(assetState.assetId, assetState.asset));
@@ -159,6 +195,15 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
         assetState.exposureAssetMax =
             uint112(bound(assetState.exposureAssetMax, expectedExposure + 1, type(uint112).max));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -174,7 +219,7 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
 
         // Then: Correct output variables are returned.
         assertEq(recursiveCalls, 1);
-        assertEq(usdExposureUpperAssetToAsset, assetState.usdExposureUpperAssetToAsset);
+        assertEq(usdExposureUpperAssetToAsset, exposureUpperAssetToAsset * assetState.rateInUsd / assetState.assetUnit);
 
         // Then: assetExposure is updated.
         bytes32 assetKey = bytes32(abi.encodePacked(assetState.assetId, assetState.asset));
@@ -194,6 +239,15 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
         // And: "exposureAsset" is strictly smaller than "exposureAssetMax" (test-case).
         assetState.exposureAssetMax = uint112(bound(assetState.exposureAssetMax, 1, type(uint112).max));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -209,7 +263,7 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
 
         // Then: Correct output variables are returned.
         assertEq(recursiveCalls, 1);
-        assertEq(usdExposureUpperAssetToAsset, assetState.usdExposureUpperAssetToAsset);
+        assertEq(usdExposureUpperAssetToAsset, exposureUpperAssetToAsset * assetState.rateInUsd / assetState.assetUnit);
 
         // Then: assetExposure is updated.
         bytes32 assetKey = bytes32(abi.encodePacked(assetState.assetId, assetState.asset));

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectDeposit.fuzz.t.sol
@@ -119,6 +119,8 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
             assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
         );
 
+        // And: Negating the delta does not overflow.
+        deltaExposureUpperAssetToAsset = bound(deltaExposureUpperAssetToAsset, 0, uint256(type(int256).max));
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -203,7 +205,6 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
             0,
             assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
         );
-
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -247,7 +248,6 @@ contract ProcessIndirectDeposit_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM
             0,
             assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
         );
-
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -160,7 +160,6 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
             0,
             assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
         );
-
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -199,7 +198,6 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
             0,
             assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
         );
-
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -29,7 +29,7 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         uint256 exposureUpperAssetToAsset,
         int256 deltaExposureUpperAssetToAsset
     ) public {
-        // Given "caller" is not the Registry.
+        // Given: "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
         // And: The value of the exposure does not overflow.

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -32,6 +32,15 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         // Given "caller" is not the Registry.
         vm.assume(unprivilegedAddress_ != address(registry));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -65,6 +74,15 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
             type(uint256).max - assetState.exposureAssetLast
         );
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -94,6 +112,15 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         uint256 expectedExposure = assetState.exposureAssetLast + deltaExposureUpperAssetToAsset;
         assetState.exposureAssetMax = uint112(bound(assetState.exposureAssetMax, expectedExposure, type(uint112).max));
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -108,7 +135,7 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         );
 
         // Then: Correct output variables are returned.
-        assertEq(usdExposureUpperAssetToAsset, assetState.usdExposureUpperAssetToAsset);
+        assertEq(usdExposureUpperAssetToAsset, exposureUpperAssetToAsset * assetState.rateInUsd / assetState.assetUnit);
 
         // And: assetExposure is updated.
         bytes32 assetKey = bytes32(abi.encodePacked(assetState.assetId, assetState.asset));
@@ -125,6 +152,15 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         deltaExposureUpperAssetToAsset = bound(deltaExposureUpperAssetToAsset, 0, assetState.exposureAssetLast);
         uint256 expectedExposure = assetState.exposureAssetLast - deltaExposureUpperAssetToAsset;
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -139,7 +175,7 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         );
 
         // Then: Correct output variables are returned.
-        assertEq(usdExposureUpperAssetToAsset, assetState.usdExposureUpperAssetToAsset);
+        assertEq(usdExposureUpperAssetToAsset, exposureUpperAssetToAsset * assetState.rateInUsd / assetState.assetUnit);
 
         // And: assetExposure is updated.
         bytes32 assetKey = bytes32(abi.encodePacked(assetState.assetId, assetState.asset));
@@ -155,6 +191,15 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         // Given: deltaExposure is bigger or equal as assetState.exposureAssetLast.
         deltaExposureUpperAssetToAsset = bound(deltaExposureUpperAssetToAsset, assetState.exposureAssetLast, INT256_MIN);
 
+        // And: The value of the exposure does not overflow.
+        assetState.assetUnit = uint64(bound(assetState.assetUnit, 1, type(uint64).max));
+        assetState.rateInUsd = bound(assetState.rateInUsd, 0, type(uint256).max / 1e18);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            assetState.rateInUsd == 0 ? type(uint256).max : type(uint256).max / assetState.rateInUsd
+        );
+
         // And: State is persisted.
         setPrimaryAMAssetState(assetState);
 
@@ -169,7 +214,7 @@ contract ProcessIndirectWithdrawal_AbstractPrimaryAM_Fuzz_Test is AbstractPrimar
         );
 
         // Then: Correct output variables are returned.
-        assertEq(usdExposureUpperAssetToAsset, assetState.usdExposureUpperAssetToAsset);
+        assertEq(usdExposureUpperAssetToAsset, exposureUpperAssetToAsset * assetState.rateInUsd / assetState.assetUnit);
 
         // And: assetExposure is updated.
         bytes32 assetKey = bytes32(abi.encodePacked(assetState.assetId, assetState.asset));

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/SetOracles.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/SetOracles.fuzz.t.sol
@@ -131,7 +131,7 @@ contract CheckOracleSequence_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fu
             vm.assume(oracleNew != oraclesOld[i]);
         }
 
-        // And one of the old oracles is not active anymore.
+        // And: one of the old oracles is not active anymore.
         vm.assume(oraclesOld[0] != oracleNew);
         oracleModule.setIsActive(oraclesOld[0], false);
 
@@ -161,11 +161,11 @@ contract CheckOracleSequence_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fu
         bytes32 oracleSequenceOld = getOracleSequence(lengthOld, directionsOld, oraclesOld);
         assetModule.setAssetInformation(asset, assetId, 0, oracleSequenceOld);
 
-        // And one of the old oracles is not active anymore.
+        // And: one of the old oracles is not active anymore.
         vm.assume(oraclesOld[0] != oracleNew);
         oracleModule.setIsActive(oraclesOld[0], false);
 
-        // And new oracles have a bad sequence.
+        // And: new oracles have a bad sequence.
         (bytes16 baseAsset, bytes16 quoteAsset) =
             directionNew ? (bytes16("A"), bytes16("NON_USD")) : (bytes16("NON_USD"), bytes16("A"));
         addMockedOracle(oracleNew, 0, baseAsset, quoteAsset, false);
@@ -196,7 +196,7 @@ contract CheckOracleSequence_AbstractPrimaryAM_Fuzz_Test is AbstractPrimaryAM_Fu
         bytes32 oracleSequenceOld = getOracleSequence(lengthOld, directionsOld, oraclesOld);
         assetModule.setAssetInformation(asset, assetId, 0, oracleSequenceOld);
 
-        // And one of the old oracles is not active anymore.
+        // And: one of the old oracles is not active anymore.
         lengthNew = bound(lengthNew, 1, 3);
         for (uint256 i; i < lengthNew; ++i) {
             vm.assume(oraclesOld[0] != oraclesNew[i]);

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/SetOracles.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/SetOracles.fuzz.t.sol
@@ -5,10 +5,9 @@
 pragma solidity ^0.8.0;
 
 import { AbstractPrimaryAM_Fuzz_Test } from "./_AbstractPrimaryAM.fuzz.t.sol";
-
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
-import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrimaryAM.sol";
 import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
+import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrimaryAM.sol";
 
 /**
  * @notice Fuzz tests for the function "checkOracleSequence" of contract "AbstractPrimaryAM".

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/_AbstractPrimaryAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/_AbstractPrimaryAM.fuzz.t.sol
@@ -4,6 +4,7 @@
  */
 pragma solidity ^0.8.0;
 
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { Fuzz_Test } from "../../Fuzz.t.sol";
 import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
 import { PrimaryAMMock } from "../../../utils/mocks/asset-modules/PrimaryAMMock.sol";
@@ -32,7 +33,8 @@ abstract contract AbstractPrimaryAM_Fuzz_Test is Fuzz_Test {
         uint96 assetId;
         uint112 exposureAssetLast;
         uint112 exposureAssetMax;
-        uint256 usdExposureUpperAssetToAsset;
+        uint64 assetUnit;
+        uint256 rateInUsd;
     }
 
     /*////////////////////////////////////////////////////////////////
@@ -41,6 +43,8 @@ abstract contract AbstractPrimaryAM_Fuzz_Test is Fuzz_Test {
 
     PrimaryAMMock internal assetModule;
     OracleModuleMock internal oracleModule;
+
+    uint256 internal constant PRIMARY_AM_ORACLE_ID = 999;
 
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -51,6 +55,8 @@ abstract contract AbstractPrimaryAM_Fuzz_Test is Fuzz_Test {
 
         vm.prank(users.owner);
         assetModule = new PrimaryAMMock(users.owner, address(registry), 0);
+
+        oracleModule = new OracleModuleMock(users.owner, address(registry));
     }
 
     /* ///////////////////////////////////////////////////////////////
@@ -65,7 +71,17 @@ abstract contract AbstractPrimaryAM_Fuzz_Test is Fuzz_Test {
         oracleModule.setRate(oracleId, rate);
     }
 
-    // forge-lint: disable-next-item(mixed-case-function)
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
+    function setPrimaryAMOracle(address asset, uint256 assetId, uint64 assetUnit, uint256 usdValue) public {
+        addMockedOracle(PRIMARY_AM_ORACLE_ID, usdValue, bytes16("A"), bytes16("USD"), true);
+        uint80[] memory oracleIds = new uint80[](1);
+        oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+        bool[] memory baseToQuoteAsset = new bool[](1);
+        baseToQuoteAsset[0] = true;
+        assetModule.setAssetInformation(asset, assetId, assetUnit, BitPackingLib.pack(baseToQuoteAsset, oracleIds));
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
     function setPrimaryAMAssetState(PrimaryAMAssetState memory assetState) internal {
         assetModule.setExposure(
             assetState.creditor,
@@ -75,6 +91,6 @@ abstract contract AbstractPrimaryAM_Fuzz_Test is Fuzz_Test {
             assetState.exposureAssetMax
         );
 
-        assetModule.setUsdValue(assetState.usdExposureUpperAssetToAsset);
+        setPrimaryAMOracle(assetState.asset, assetState.assetId, assetState.assetUnit, assetState.rateInUsd);
     }
 }

--- a/test/fuzz/asset-modules/AbstractPrimaryAM/_AbstractPrimaryAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractPrimaryAM/_AbstractPrimaryAM.fuzz.t.sol
@@ -18,8 +18,7 @@ abstract contract AbstractPrimaryAM_Fuzz_Test is Fuzz_Test {
     /////////////////////////////////////////////////////////////// */
 
     uint256 internal constant INT256_MAX = 2 ** 255 - 1;
-    // While the true minimum value of an int256 is 2 ** 255, Solidity overflows on a negation (since INT256_MAX is one less).
-    // -> This true minimum value will overflow and revert.
+    // Negating the true minimum of 2 ** 255 overflows, so this stops one below it.
     uint256 internal constant INT256_MIN = 2 ** 255 - 1;
 
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/AbstractStakingAM/Burn.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/Burn.fuzz.t.sol
@@ -43,10 +43,7 @@ contract Burn_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
             vm.assume(account_ != asset);
 
             // Given: Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-            // And : Account has a non-zero balance.
-            vm.assume(positionState.amountStaked > 0);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
             // And: State is persisted.
             setStakingAMState(assetState, positionState, asset, positionId);
@@ -123,10 +120,7 @@ contract Burn_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
             vm.assume(account_ != asset);
 
             // Given: Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-            // And : Account has a non-zero balance.
-            vm.assume(positionState.amountStaked > 0);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
             // And reward is zero.
             positionState.lastRewardPosition = 0;

--- a/test/fuzz/asset-modules/AbstractStakingAM/Burn.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/Burn.fuzz.t.sol
@@ -122,7 +122,7 @@ contract Burn_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
             // Given: Valid state
             (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
-            // And reward is zero.
+            // And: reward is zero.
             positionState.lastRewardPosition = 0;
             positionState.lastRewardPerTokenPosition = assetState.lastRewardPerTokenGlobal;
             assetState.currentRewardGlobal = 0;

--- a/test/fuzz/asset-modules/AbstractStakingAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -34,7 +34,7 @@ contract CalculateValueAndRiskFactors_AbstractStakingAM_Fuzz_Test is AbstractSta
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         assetRates[0] = bound(assetRates[0], 0, type(uint64).max);
@@ -52,7 +52,7 @@ contract CalculateValueAndRiskFactors_AbstractStakingAM_Fuzz_Test is AbstractSta
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         stakingAM.setRiskParameters(creditor, 0, riskFactor);
 
@@ -84,7 +84,7 @@ contract CalculateValueAndRiskFactors_AbstractStakingAM_Fuzz_Test is AbstractSta
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // And riskFactor is set.
+        // And: riskFactor is set.
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
         vm.prank(address(registry));
         stakingAM.setRiskParameters(creditor, 0, riskFactor);

--- a/test/fuzz/asset-modules/AbstractStakingAM/ClaimReward.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/ClaimReward.fuzz.t.sol
@@ -58,7 +58,7 @@ contract ClaimReward_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test 
         address asset = addAsset(assetDecimals);
 
         // Given: Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);
@@ -127,7 +127,7 @@ contract ClaimReward_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test 
         address asset = addAsset(assetDecimals);
 
         // Given: Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
         // And reward is zero.
         positionState.lastRewardPosition = 0;

--- a/test/fuzz/asset-modules/AbstractStakingAM/ClaimReward.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/ClaimReward.fuzz.t.sol
@@ -66,7 +66,7 @@ contract ClaimReward_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test 
         // Given : The claim function on the external staking contract is not implemented, thus we fund the stakingAM with reward tokens that should be transferred.
         uint256 currentRewardPosition = stakingAM.rewardOf(positionId);
 
-        // And reward is non-zero.
+        // And: reward is non-zero.
         vm.assume(currentRewardPosition > 0);
         deal(address(stakingAM.REWARD_TOKEN()), address(stakingAM), currentRewardPosition, true);
 
@@ -129,7 +129,7 @@ contract ClaimReward_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test 
         // Given: Valid state
         (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
-        // And reward is zero.
+        // And: reward is zero.
         positionState.lastRewardPosition = 0;
         positionState.lastRewardPerTokenPosition = assetState.lastRewardPerTokenGlobal;
         assetState.currentRewardGlobal = 0;

--- a/test/fuzz/asset-modules/AbstractStakingAM/DecreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/DecreaseLiquidity.fuzz.t.sol
@@ -265,7 +265,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         // Given : Valid state
         (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
-        // And reward is zero.
+        // And: reward is zero.
         positionState.lastRewardPosition = 0;
         positionState.lastRewardPerTokenPosition = assetState.lastRewardPerTokenGlobal;
         assetState.currentRewardGlobal = 0;
@@ -338,7 +338,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
             // Given : Valid state
             (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 2, type(uint128).max);
 
-            // And reward is zero.
+            // And: reward is zero.
             positionState.lastRewardPosition = 0;
             positionState.lastRewardPerTokenPosition = assetState.lastRewardPerTokenGlobal;
             assetState.currentRewardGlobal = 0;

--- a/test/fuzz/asset-modules/AbstractStakingAM/DecreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/DecreaseLiquidity.fuzz.t.sol
@@ -40,7 +40,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
 
     function testFuzz_Revert_decreaseLiquidity_NotOwner(uint256 id, uint128 amount, address owner) public {
         // Given : Amount is greater than 0.
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
 
         // Given : Owner is not the caller.
         vm.assume(owner != users.accountOwner);
@@ -69,12 +69,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         vm.assume(account_ != address(stakingAM));
         vm.assume(account_ != address(rewardToken));
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-        // And : Account has a non-zero balance.
-        vm.assume(positionState.amountStaked > 0);
-        // And : Account has a balance smaller as type(uint128).max.
-        vm.assume(positionState.amountStaked < type(uint128).max);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);
@@ -109,10 +104,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         vm.assume(account_ != asset);
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-        // And : Account has a non-zero balance
-        vm.assume(positionState.amountStaked > 0);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);
@@ -192,10 +184,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
             vm.assume(account_ != asset);
 
             // Given : Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-            // And : Account has a balance bigger as 1.
-            vm.assume(positionState.amountStaked > 1);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 2, type(uint128).max);
 
             // And: State is persisted.
             setStakingAMState(assetState, positionState, asset, positionId);
@@ -274,10 +263,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         vm.assume(account_ != asset);
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-        // And : Account has a non-zero balance
-        vm.assume(positionState.amountStaked > 0);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
         // And reward is zero.
         positionState.lastRewardPosition = 0;
@@ -350,10 +336,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
             vm.assume(account_ != asset);
 
             // Given : Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-            // And : Account has a balance bigger as 1.
-            vm.assume(positionState.amountStaked > 1);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 2, type(uint128).max);
 
             // And reward is zero.
             positionState.lastRewardPosition = 0;

--- a/test/fuzz/asset-modules/AbstractStakingAM/DecreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/DecreaseLiquidity.fuzz.t.sol
@@ -69,7 +69,7 @@ contract DecreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         vm.assume(account_ != address(stakingAM));
         vm.assume(account_ != address(rewardToken));
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max - 1);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);

--- a/test/fuzz/asset-modules/AbstractStakingAM/GetRewardBalances.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/GetRewardBalances.fuzz.t.sol
@@ -238,7 +238,7 @@ contract GetRewardBalances_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         address asset = addAsset(assetDecimals);
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);
@@ -276,7 +276,7 @@ contract GetRewardBalances_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
         address asset = addAsset(assetDecimals);
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);

--- a/test/fuzz/asset-modules/AbstractStakingAM/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/IncreaseLiquidity.fuzz.t.sol
@@ -40,9 +40,9 @@ contract IncreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
     ) public canReceiveERC721(account_) {
         vm.assume(account_ != randomAddress);
         // Given : Amount is greater than zero
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
         // Given : positionId is greater than 0
-        vm.assume(positionId > 0);
+        positionId = uint96(bound(positionId, 1, type(uint96).max));
         // Given : Owner of positionId is not the Account
         stakingAM.setOwnerOfPositionId(randomAddress, positionId);
         // Given : A staking token is added to the stakingAM
@@ -74,7 +74,7 @@ contract IncreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
             asset = addAsset(assetDecimals);
 
             // Given : Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max - 1);
 
             // And: State is persisted.
             setStakingAMState(assetState, positionState, asset, positionId);
@@ -84,7 +84,6 @@ contract IncreaseLiquidity_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz
 
             // And: updated totalStake should not be greater than uint128.
             // And: Amount staked is greater than zero.
-            vm.assume(assetState.totalStaked < type(uint128).max);
             amount = uint128(bound(amount, 1, type(uint128).max - assetState.totalStaked));
 
             deal(asset, account_, amount, true);

--- a/test/fuzz/asset-modules/AbstractStakingAM/Mint.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/Mint.fuzz.t.sol
@@ -33,7 +33,7 @@ contract Mint_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
 
     function testFuzz_Revert_mint_AssetNotAllowed(uint8 assetDecimals, uint128 amount, address account_) public {
         // Given : Amount is greater than zero
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
 
         assetDecimals = uint8(bound(assetDecimals, 0, 18));
         address asset = address(new ERC20Mock("Asset", "AST", assetDecimals));
@@ -73,14 +73,13 @@ contract Mint_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
 
             // And: Valid state.
             StakingAM.PositionState memory positionState;
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max - 1);
 
             // And: State is persisted.
             setStakingAMState(assetState, positionState, asset, 0);
 
             // And: updated totalStake should not be greater than uint128.
             // And: Amount staked is greater than zero.
-            vm.assume(assetState.totalStaked < type(uint128).max);
             amount = uint128(bound(amount, 1, type(uint128).max - assetState.totalStaked));
 
             deal(asset, account_, amount, true);
@@ -141,7 +140,7 @@ contract Mint_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
 
         // And: Valid state.
         StakingAM.PositionState memory positionState;
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max - 1);
 
         // And: TotalStaked is 0.
         assetState.totalStaked = 0;

--- a/test/fuzz/asset-modules/AbstractStakingAM/RewardOf.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/RewardOf.fuzz.t.sol
@@ -10,6 +10,7 @@ import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointM
 /**
  * @notice Fuzz tests for the function "rewardOf" of contract "StakingAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract RewardOf_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
 
@@ -35,10 +36,7 @@ contract RewardOf_AbstractStakingAM_Fuzz_Test is AbstractStakingAM_Fuzz_Test {
         address asset = addAsset(assetDecimals);
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-        // And : Account has a non-zero balance
-        vm.assume(positionState.amountStaked > 0);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
         // And: State is persisted.
         setStakingAMState(assetState, positionState, asset, positionId);

--- a/test/fuzz/asset-modules/AbstractStakingAM/_AbstractStakingAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AbstractStakingAM/_AbstractStakingAM.fuzz.t.sol
@@ -78,14 +78,19 @@ abstract contract AbstractStakingAM_Fuzz_Test is Fuzz_Test {
     // forge-lint: disable-next-item(mixed-case-function,mixed-case-variable)
     function givenValidStakingAMState(
         StakingAMStateForAsset memory stakingAMStateForAsset,
-        StakingAM.PositionState memory stakingAMStateForPosition
+        StakingAM.PositionState memory stakingAMStateForPosition,
+        uint128 minAmountStaked,
+        uint128 maxTotalStaked
     ) public pure returns (StakingAMStateForAsset memory, StakingAM.PositionState memory) {
         // Given: More than 1 gwei is staked.
-        stakingAMStateForAsset.totalStaked = uint128(bound(stakingAMStateForAsset.totalStaked, 1, type(uint128).max));
+        stakingAMStateForAsset.totalStaked = uint128(
+            bound(stakingAMStateForAsset.totalStaked, minAmountStaked == 0 ? 1 : minAmountStaked, maxTotalStaked)
+        );
 
         // And: totalStaked should be >= to amountStakedForPosition (invariant).
-        stakingAMStateForPosition.amountStaked =
-            uint128(bound(stakingAMStateForPosition.amountStaked, 0, stakingAMStateForAsset.totalStaked));
+        stakingAMStateForPosition.amountStaked = uint128(
+            bound(stakingAMStateForPosition.amountStaked, minAmountStaked, stakingAMStateForAsset.totalStaked)
+        );
 
         // And: deltaRewardPerToken is smaller or equal as type(uint128).max (no overflow safeCastTo128).
         stakingAMStateForAsset.currentRewardGlobal = bound(

--- a/test/fuzz/asset-modules/AerodromePoolAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -33,7 +33,7 @@ contract CalculateValueAndRiskFactors_AerodromePoolAM_Fuzz_Test is AerodromePool
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         assetRates[0] = bound(assetRates[0], 0, type(uint64).max);
@@ -50,7 +50,7 @@ contract CalculateValueAndRiskFactors_AerodromePoolAM_Fuzz_Test is AerodromePool
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         aeroPoolAM.setRiskParameters(creditor, 0, riskFactor);
 

--- a/test/fuzz/asset-modules/AerodromePoolAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/GetRiskFactors.fuzz.t.sol
@@ -51,7 +51,7 @@ contract GetRiskFactors_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
             ? uint256(riskFactor).mulDivDown(liquidationFactor0, AssetValuationLib.ONE_4)
             : uint256(riskFactor).mulDivDown(liquidationFactor1, AssetValuationLib.ONE_4);
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         aeroPoolAM.setRiskParameters(creditor, 0, riskFactor);
 
@@ -60,10 +60,10 @@ contract GetRiskFactors_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
         vm.prank(users.owner);
         aeroPoolAM.addAsset(address(aeroPool));
 
-        // And riskFactors are set for token0.
+        // And: riskFactors are set for token0.
         vm.startPrank(address(registry));
         erc20AM.setRiskParameters(creditor, address(mockERC20.token1), 0, 0, collateralFactor0, liquidationFactor0);
-        // And riskFactors are set for token1.
+        // And: riskFactors are set for token1.
         erc20AM.setRiskParameters(creditor, address(mockERC20.stable1), 0, 0, collateralFactor1, liquidationFactor1);
         vm.stopPrank();
 

--- a/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -189,10 +189,10 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // Given : Valid state
         testVars = givenValidTestVarsStable(testVars);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
-        // And reserves are increased to that k reverts.
+        // And: reserves are increased to that k reverts.
         reserve0_ = bound(reserve0_, 15_511_800_965 * 10 ** testVars.decimals0, type(uint256).max);
         reserve1_ = bound(reserve1_, 15_511_800_965 * 10 ** testVars.decimals1, type(uint256).max);
         stdstore.target(address(aeroPool)).sig(aeroPool.reserve0.selector).checked_write(reserve0_);
@@ -251,7 +251,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         );
         vm.assume(k / testVars.priceToken0 > type(uint256).max / testVars.priceToken1);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -313,7 +313,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And: c does not overflow
         vm.assume(k / testVars.priceToken0 <= type(uint256).max / testVars.priceToken1);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -372,7 +372,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And: x overflows (test-case).
         vm.assume(c / d > type(uint256).max / 1e36);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -439,7 +439,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         vm.assume(trustedReserve0 > 1);
         testVars.assetAmount = bound(testVars.assetAmount, type(uint256).max / trustedReserve0 + 1, type(uint256).max);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -511,7 +511,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         vm.assume(trustedReserve1 > 1);
         testVars.assetAmount = bound(testVars.assetAmount, type(uint256).max / trustedReserve1 + 1, type(uint256).max);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -538,7 +538,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And : rate of asset0 is zero.
         testVars.priceToken0 = 0;
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -570,7 +570,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And : rate of asset0 is zero.
         testVars.priceToken1 = 0;
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -601,7 +601,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // Given : Valid state
         testVars = givenValidTestVarsVolatile(testVars);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         uint256[] memory underlyingAssetsAmounts;
@@ -693,7 +693,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // Given : Valid state
         testVars = givenValidTestVarsVolatile(testVars);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         uint256[] memory underlyingAssetsAmounts;
@@ -746,7 +746,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And : rate of asset0 is zero.
         testVars.priceToken0 = 0;
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -778,7 +778,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And : rate of asset0 is zero.
         testVars.priceToken1 = 0;
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(aeroPool)));
@@ -809,7 +809,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // Given : Valid state
         testVars = givenValidTestVarsStable(testVars);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         uint256 trustedReserve0;
@@ -911,7 +911,7 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // Given : Valid state
         testVars = givenValidTestVarsStable(testVars);
 
-        // And state is persisted.
+        // And: state is persisted.
         testVars = initAndSetValidStateInPoolFixture(testVars);
 
         uint256 trustedReserve0;

--- a/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -601,7 +601,6 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
     function testFuzz_Success_getUnderlyingAssetsAmounts_Volatile_NonZeroRate_NoPrecisionLoss(TestVariables memory testVars)
         public
     {
-        vm.skip(true); // TODO: fix test
         // Given : Valid state
         testVars = givenValidTestVarsVolatile(testVars);
 

--- a/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -227,13 +227,12 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         uint256 decimalDifference = d0BiggerD1 ? 10 ** (testVars.decimals0 - testVars.decimals1) : 1;
         // And: k does not overflow (-> r <= sqrt(sqrt(type(uint256).max * 10 ** (4 * decimals - 36) / 2)))
         //                           -> r < 10 ** decimals * 15511800964 (approximated)
-        testVars.reserve0 = bound(testVars.reserve0, decimalDifference, 15_511_800_964 * 10 ** testVars.decimals0);
+        testVars.reserve0 = bound(
+            testVars.reserve0, MINIMUM_LIQUIDITY * decimalDifference + 1, 15_511_800_964 * 10 ** testVars.decimals0
+        );
         // And : Reserves should be deposited in same proportion for first mint.
         testVars.reserve0 = testVars.reserve0 / decimalDifference * decimalDifference;
         testVars.reserve1 = convertToDecimals(testVars.reserve0, testVars.decimals0, testVars.decimals1);
-
-        // Root (reserve0 * reserve1) should be greater than minimum liquidty
-        vm.assume(testVars.reserve0 * testVars.reserve1 > MINIMUM_LIQUIDITY ** 2);
 
         uint256 k = getK(testVars.reserve0, testVars.reserve1, 10 ** testVars.decimals0, 10 ** testVars.decimals1);
 
@@ -285,13 +284,14 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         uint256 decimalDifference = d0BiggerD1 ? 10 ** (testVars.decimals0 - testVars.decimals1) : 1;
         // And: k does not overflow (-> r <= sqrt(sqrt(type(uint256).max * 10 ** (4 * decimals - 36) / 2)))
         //                           -> r < 10 ** decimals * 15511800964 (approximated)
-        testVars.reserve0 = bound(testVars.reserve0, decimalDifference, 15_511_800_964 * 10 ** testVars.decimals0);
+        testVars.reserve0 = bound(
+            testVars.reserve0, MINIMUM_LIQUIDITY * decimalDifference + 1, 15_511_800_964 * 10 ** testVars.decimals0
+        );
         // And : Reserves should be deposited in same proportion for first mint.
         testVars.reserve0 = testVars.reserve0 / decimalDifference * decimalDifference;
         testVars.reserve1 = convertToDecimals(testVars.reserve0, testVars.decimals0, testVars.decimals1);
 
         // Root (reserve0 * reserve1) should be greater than minimum liquidity
-        vm.assume(testVars.reserve0 * testVars.reserve1 > MINIMUM_LIQUIDITY ** 2);
 
         uint256 k = getK(testVars.reserve0, testVars.reserve1, 10 ** testVars.decimals0, 10 ** testVars.decimals1);
 
@@ -346,13 +346,12 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         uint256 decimalDifference = d0BiggerD1 ? 10 ** (testVars.decimals0 - testVars.decimals1) : 1;
         // And: k does not overflow (-> r <= sqrt(sqrt(type(uint256).max * 10 ** (4 * decimals - 36) / 2)))
         //                           -> r < 10 ** decimals * 15511800964 (approximated)
-        testVars.reserve0 = bound(testVars.reserve0, decimalDifference, 15_511_800_964 * 10 ** testVars.decimals0);
+        testVars.reserve0 = bound(
+            testVars.reserve0, MINIMUM_LIQUIDITY * decimalDifference + 1, 15_511_800_964 * 10 ** testVars.decimals0
+        );
         // And : Reserves should be deposited in same proportion for first mint.
         testVars.reserve0 = testVars.reserve0 / decimalDifference * decimalDifference;
         testVars.reserve1 = convertToDecimals(testVars.reserve0, testVars.decimals0, testVars.decimals1);
-
-        // Root (reserve0 * reserve1) should be greater than minimum liquidty
-        vm.assume(testVars.reserve0 * testVars.reserve1 > MINIMUM_LIQUIDITY ** 2);
 
         uint256 k = getK(testVars.reserve0, testVars.reserve1, 10 ** testVars.decimals0, 10 ** testVars.decimals1);
 
@@ -408,13 +407,12 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         uint256 decimalDifference = d0BiggerD1 ? 10 ** (testVars.decimals0 - testVars.decimals1) : 1;
         // And: k does not overflow (-> r <= sqrt(sqrt(type(uint256).max * 10 ** (4 * decimals - 36) / 2)))
         //                           -> r < 10 ** decimals * 15511800964 (approximated)
-        testVars.reserve0 = bound(testVars.reserve0, decimalDifference, 15_511_800_964 * 10 ** testVars.decimals0);
+        testVars.reserve0 = bound(
+            testVars.reserve0, MINIMUM_LIQUIDITY * decimalDifference + 1, 15_511_800_964 * 10 ** testVars.decimals0
+        );
         // And : Reserves should be deposited in same proportion for first mint.
         testVars.reserve0 = testVars.reserve0 / decimalDifference * decimalDifference;
         testVars.reserve1 = convertToDecimals(testVars.reserve0, testVars.decimals0, testVars.decimals1);
-
-        // Root (reserve0 * reserve1) should be greater than minimum liquidty
-        vm.assume(testVars.reserve0 * testVars.reserve1 > MINIMUM_LIQUIDITY ** 2);
 
         uint256 k = getK(testVars.reserve0, testVars.reserve1, 10 ** testVars.decimals0, 10 ** testVars.decimals1);
 
@@ -476,13 +474,12 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         uint256 decimalDifference = d0BiggerD1 ? 10 ** (testVars.decimals0 - testVars.decimals1) : 1;
         // And: k does not overflow (-> r <= sqrt(sqrt(type(uint256).max * 10 ** (4 * decimals - 36) / 2)))
         //                           -> r < 10 ** decimals * 15511800964 (approximated)
-        testVars.reserve0 = bound(testVars.reserve0, decimalDifference, 15_511_800_964 * 10 ** testVars.decimals0);
+        testVars.reserve0 = bound(
+            testVars.reserve0, MINIMUM_LIQUIDITY * decimalDifference + 1, 15_511_800_964 * 10 ** testVars.decimals0
+        );
         // And : Reserves should be deposited in same proportion for first mint.
         testVars.reserve0 = testVars.reserve0 / decimalDifference * decimalDifference;
         testVars.reserve1 = convertToDecimals(testVars.reserve0, testVars.decimals0, testVars.decimals1);
-
-        // Root (reserve0 * reserve1) should be greater than minimum liquidty
-        vm.assume(testVars.reserve0 * testVars.reserve1 > MINIMUM_LIQUIDITY ** 2);
 
         uint256 k = getK(testVars.reserve0, testVars.reserve1, 10 ** testVars.decimals0, 10 ** testVars.decimals1);
 
@@ -647,10 +644,12 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And: The amounts should be in balance with the external prices.
         // For very low amounts, a rounding error already invalidates the assertions.
         // "assertApproxEqRel()" should not overflow.
-        if (underlyingAssetsAmounts[0] > 1e2 && underlyingAssetsAmounts[1] > 1e2) {
+        if (underlyingAssetsAmounts[0] > 1e3 && underlyingAssetsAmounts[1] > 1e3) {
             if (
                 underlyingAssetsAmounts[0] > underlyingAssetsAmounts[1]
                     && 1e18 * testVars.priceToken1 / testVars.priceToken0 < type(uint256).max / 1e18
+                    && underlyingAssetsAmounts[0]
+                        < type(uint256).max / 10 ** (18 + testVars.decimals1 - testVars.decimals0)
             ) {
                 assertApproxEqRel(
                     10 ** (18 + testVars.decimals1 - testVars.decimals0) * underlyingAssetsAmounts[0]
@@ -658,7 +657,11 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
                     1e18 * testVars.priceToken1 / testVars.priceToken0,
                     1e16
                 );
-            } else if (1e18 * testVars.priceToken0 / testVars.priceToken1 < type(uint256).max / 1e18) {
+            } else if (
+                1e18 * testVars.priceToken0 / testVars.priceToken1 < type(uint256).max / 1e18
+                    && underlyingAssetsAmounts[1]
+                        < type(uint256).max / 10 ** (18 + testVars.decimals0 - testVars.decimals1)
+            ) {
                 assertApproxEqRel(
                     10 ** (18 + testVars.decimals0 - testVars.decimals1) * underlyingAssetsAmounts[1]
                         / underlyingAssetsAmounts[0],
@@ -671,11 +674,13 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
         // And: k-value of the aeroPool with trustedReserves remains the same.
         // For very low reserves, a rounding error already invalidates the assertions.
         // "assertApproxEqRel()" should not overflow.
-        uint256 kNew = trustedReserve0 * trustedReserve1;
+        uint256 kNew;
         if (k > type(uint256).max / 1e18) {
             // "assertApproxEqRel()" should not overflow.
+            kNew = FullMath.mulDiv(trustedReserve0, trustedReserve1, 1e18);
             k = k / 1e18;
-            kNew = kNew / 1e18;
+        } else {
+            kNew = trustedReserve0 * trustedReserve1;
         }
         if (trustedReserve0 > 5e3 && trustedReserve1 > 5e4) {
             assertApproxEqRel(kNew, k, 1e16);
@@ -864,6 +869,8 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
             if (
                 underlyingAssetsAmounts[0] > underlyingAssetsAmounts[1]
                     && 1e18 * testVars.priceToken1 / testVars.priceToken0 < type(uint256).max / 1e18
+                    && underlyingAssetsAmounts[0]
+                        < type(uint256).max / 10 ** (18 + testVars.decimals1 - testVars.decimals0)
             ) {
                 assertApproxEqRel(
                     10 ** (18 + testVars.decimals1 - testVars.decimals0) * underlyingAssetsAmounts[0]
@@ -871,7 +878,11 @@ contract GetUnderlyingAssetsAmounts_AerodromePoolAM_Fuzz_Test is AerodromePoolAM
                     1e18 * testVars.priceToken1 / testVars.priceToken0,
                     1e16
                 );
-            } else if (1e18 * testVars.priceToken0 / testVars.priceToken1 < type(uint256).max / 1e18) {
+            } else if (
+                1e18 * testVars.priceToken0 / testVars.priceToken1 < type(uint256).max / 1e18
+                    && underlyingAssetsAmounts[1]
+                        < type(uint256).max / 10 ** (18 + testVars.decimals0 - testVars.decimals1)
+            ) {
                 assertApproxEqRel(
                     10 ** (18 + testVars.decimals0 - testVars.decimals1) * underlyingAssetsAmounts[1]
                         / underlyingAssetsAmounts[0],

--- a/test/fuzz/asset-modules/AerodromePoolAM/_AerodromePoolAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/_AerodromePoolAM.fuzz.t.sol
@@ -169,13 +169,12 @@ abstract contract AerodromePoolAM_Fuzz_Test is Fuzz_Test, AerodromeFixture {
         uint256 decimalDifference = d0BiggerD1 ? 10 ** (testVars.decimals0 - testVars.decimals1) : 1;
         // And: k does not overflow (-> r <= sqrt(sqrt(type(uint256).max * 10 ** (4 * decimals - 36) / 2)))
         //                           -> r < 10 ** decimals * 15511800964 (approximated)
-        testVars.reserve0 = bound(testVars.reserve0, decimalDifference, 15_511_800_964 * 10 ** testVars.decimals0);
+        testVars.reserve0 = bound(
+            testVars.reserve0, MINIMUM_LIQUIDITY * decimalDifference + 1, 15_511_800_964 * 10 ** testVars.decimals0
+        );
         // And : Reserves should be deposited in same proportion for first mint.
         testVars.reserve0 = testVars.reserve0 / decimalDifference * decimalDifference;
         testVars.reserve1 = convertToDecimals(testVars.reserve0, testVars.decimals0, testVars.decimals1);
-
-        // Root (reserve0 * reserve1) should be greater than minimum liquidty
-        vm.assume(testVars.reserve0 * testVars.reserve1 > MINIMUM_LIQUIDITY ** 2);
 
         uint256 k = getK(testVars.reserve0, testVars.reserve1, 10 ** testVars.decimals0, 10 ** testVars.decimals1);
 

--- a/test/fuzz/asset-modules/AerodromePoolAM/isAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/AerodromePoolAM/isAllowed.fuzz.t.sol
@@ -5,7 +5,7 @@
 pragma solidity ^0.8.0;
 
 import { AerodromePoolAM_Fuzz_Test } from "./_AerodromePoolAM.fuzz.t.sol";
-import { stdStorage, StdStorage } from "../../../../lib/forge-std/src/StdStorage.sol";
+import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/StdStorage.sol";
 
 /**
  * @notice Fuzz tests for the function "isAllowed" of contract "AerodromePoolAM".
@@ -25,21 +25,23 @@ contract IsAllowed_AerodromePoolAM_Fuzz_Test is AerodromePoolAM_Fuzz_Test {
     /////////////////////////////////////////////////////////////// */
 
     function testFuzz_Success_isAllowed_False(address asset, uint256 id) public view {
-        // When : Calling isAllowed()
+        // Given: The asset is not in the Asset Module.
+
+        // When: The asset is checked.
         bool allowed = aeroPoolAM.isAllowed(asset, id);
 
-        // Then : It should return false
+        // Then: It is not allowed.
         assertFalse(allowed);
     }
 
     function testFuzz_Success_isAllowed_True(address asset, uint256 id) public {
-        // Given: asset is in the aeroPoolAM.
+        // Given: The asset is in the Asset Module.
         stdstore.target(address(aeroPoolAM)).sig(aeroPoolAM.inAssetModule.selector).with_key(asset).checked_write(true);
 
-        // When : Calling isAllowed()
+        // When: The asset is checked.
         bool allowed = aeroPoolAM.isAllowed(asset, id);
 
-        // Then : It should return true
+        // Then: It is allowed.
         assertTrue(allowed);
     }
 }

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/AddAsset.fuzz.t.sol
@@ -69,7 +69,7 @@ contract AddAsset_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
         );
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -86,7 +86,7 @@ contract AddAsset_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -115,7 +115,7 @@ contract AddAsset_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(nativeTokenPoolKey.toId(), positionKey, liquidity);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -33,7 +33,7 @@ contract CalculateValueAndRiskFactors_DefaultUniswapV4AM_Fuzz_Test is DefaultUni
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         assetRates[0] = bound(assetRates[0], 0, type(uint64).max);
@@ -50,7 +50,7 @@ contract CalculateValueAndRiskFactors_DefaultUniswapV4AM_Fuzz_Test is DefaultUni
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(v4HooksRegistry));
         uniswapV4AM.setRiskParameters(creditor, 0, riskFactor);
 

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetFeeAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetFeeAmounts.fuzz.t.sol
@@ -7,7 +7,9 @@ pragma solidity ^0.8.0;
 import { DefaultUniswapV4AM_Fuzz_Test } from "./_DefaultUniswapV4AM.fuzz.t.sol";
 import { FixedPoint128 } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/FixedPoint128.sol";
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
+import { FullMath } from "../../../../src/asset-modules/UniswapV3/libraries/FullMath.sol";
 import { PositionInfo, PositionInfoLibrary } from "../../../../lib/v4-periphery/src/libraries/PositionInfoLibrary.sol";
+import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
 
 /**
  * @notice Fuzz tests for the function "_getFeeAmounts" of contract "DefaultUniswapV4AM".
@@ -35,7 +37,7 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         int24 tickUpper
     ) public {
         // Given : Liquidity is > 0
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
 
         // And : Positive fee
         feeData.desiredFee0 = bound(feeData.desiredFee0, 1, type(uint128).max);
@@ -58,8 +60,8 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         {
             // And : Current tick should be < lower tick
             (, int24 currentTick,,) = stateView.getSlot0(stablePoolKey.toId());
-            tickLower = int24(bound(tickLower, currentTick + 1, MAX_TICK - 1));
-            tickUpper = int24(bound(tickUpper, tickLower + 1, MAX_TICK));
+            tickLower = int24(bound(tickLower, currentTick + 1, TickMath.MAX_TICK - 1));
+            tickUpper = int24(bound(tickUpper, tickLower + 1, TickMath.MAX_TICK));
 
             // And : Position is set
             bytes32 positionKey = keccak256(
@@ -101,7 +103,7 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         int24 tickUpper
     ) public {
         // Given : Liquidity is > 0
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
 
         // And : Positive fee
         feeData.desiredFee0 = bound(feeData.desiredFee0, 1, type(uint128).max);
@@ -124,8 +126,8 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         {
             // And : Current tick should be > upper tick
             (, int24 currentTick,,) = stateView.getSlot0(stablePoolKey.toId());
-            tickUpper = int24(bound(tickUpper, MIN_TICK + 2, currentTick - 1));
-            tickLower = int24(bound(tickLower, MIN_TICK, tickUpper - 1));
+            tickUpper = int24(bound(tickUpper, TickMath.MIN_TICK + 2, currentTick - 1));
+            tickLower = int24(bound(tickLower, TickMath.MIN_TICK, tickUpper - 1));
 
             // And : Position is set
             bytes32 positionKey = keccak256(
@@ -167,7 +169,7 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         int24 tickUpper
     ) public {
         // Given : Liquidity is > 0
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
 
         // And : Positive fee
         feeData.desiredFee0 = bound(feeData.desiredFee0, 1, type(uint128).max);
@@ -186,8 +188,8 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         {
             // And : Position should be in range
             (, int24 currentTick,,) = stateView.getSlot0(stablePoolKey.toId());
-            tickLower = int24(bound(tickLower, MIN_TICK, currentTick - 1));
-            tickUpper = int24(bound(tickUpper, currentTick + 1, MAX_TICK));
+            tickLower = int24(bound(tickLower, TickMath.MIN_TICK, currentTick - 1));
+            tickUpper = int24(bound(tickUpper, currentTick + 1, TickMath.MAX_TICK));
 
             // And : Position is set
             bytes32 positionKey = keccak256(
@@ -223,11 +225,7 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         uint128 liquidity
     ) public {
         // Given : Liquidity is > 0
-        vm.assume(liquidity > 0);
-
-        // And : Positive fee
-        feeData.desiredFee0 = bound(feeData.desiredFee0, 1, type(uint128).max - 1);
-        feeData.desiredFee1 = bound(feeData.desiredFee1, 1, type(uint128).max - 1);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
 
         // And : Positive freeGrowthInsideLast
         feeGrowthInside0LastX128 = bound(feeGrowthInside0LastX128, 1, type(uint96).max);
@@ -235,17 +233,29 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         feeGrowthInside1LastX128 = bound(feeGrowthInside1LastX128, 1, type(uint96).max);
         feeGrowthInside1LastX128 *= FixedPoint128.Q128;
 
+        // And : Positive fee, for which feeGrowthGlobal does not overflow.
+        {
+            uint256 maxFee =
+                FullMath.mulDiv(type(uint256).max - feeGrowthInside0LastX128 - 1, liquidity, FixedPoint128.Q128);
+            if (maxFee > type(uint128).max - 1) maxFee = type(uint128).max - 1;
+            feeData.desiredFee0 = bound(feeData.desiredFee0, 1, maxFee);
+        }
+        {
+            uint256 maxFee =
+                FullMath.mulDiv(type(uint256).max - feeGrowthInside1LastX128 - 1, liquidity, FixedPoint128.Q128);
+            if (maxFee > type(uint128).max - 1) maxFee = type(uint128).max - 1;
+            feeData.desiredFee1 = bound(feeData.desiredFee1, 1, maxFee);
+        }
+
         // And : Calculate expected feeGrowth difference in order to obtain desired fee
         // (fee * Q128) / liquidity = diff in Q128.
         // As fee amount is calculated based on deducting feeGrowthOutside from feeGrowthGlobal,
         // no need to test with fuzzed feeGrowthOutside values as no risk of potential rounding errors (we're not testing UniV4 contracts).
         uint256 feeGrowthDiff0X128 = feeData.desiredFee0.mulDivDown(FixedPoint128.Q128, liquidity);
-        vm.assume(feeGrowthDiff0X128 < type(uint256).max - feeGrowthInside0LastX128);
 
         feeData.feeGrowthGlobal0X128 = feeGrowthDiff0X128 + feeGrowthInside0LastX128;
 
         uint256 feeGrowthDiff1X128 = feeData.desiredFee1.mulDivDown(FixedPoint128.Q128, liquidity);
-        vm.assume(feeGrowthDiff1X128 < type(uint256).max - feeGrowthInside1LastX128);
 
         feeData.feeGrowthGlobal1X128 = feeGrowthDiff1X128 + feeGrowthInside1LastX128;
 
@@ -253,8 +263,8 @@ contract GetFeeAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_T
         {
             // And : Position should be in range
             (, int24 currentTick,,) = stateView.getSlot0(stablePoolKey.toId());
-            tickLower = int24(bound(tickLower, MIN_TICK, currentTick - 1));
-            tickUpper = int24(bound(tickUpper, currentTick + 1, MAX_TICK));
+            tickLower = int24(bound(tickLower, TickMath.MIN_TICK, currentTick - 1));
+            tickUpper = int24(bound(tickUpper, currentTick + 1, TickMath.MAX_TICK));
 
             // And : Position is set
             positionKey = keccak256(

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetPrincipalAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetPrincipalAmounts.fuzz.t.sol
@@ -34,15 +34,10 @@ contract GetPrincipalAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_
         uint256 priceToken1
     ) public view {
         // Given : Ticks are within allowed ranges.
-        tickLower = int24(bound(tickLower, MIN_TICK, MAX_TICK - 2));
-        tickUpper = int24(bound(tickUpper, tickLower + 1, MAX_TICK));
+        tickLower = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
+        tickUpper = int24(bound(tickUpper, tickLower + 1, TickMath.MAX_TICK));
 
-        // And : Avoid divide by 0, which is already checked in earlier in function.
-        vm.assume(priceToken1 > 0);
-        // Function will overFlow, not realistic.
-        priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
 
         // Generate PositionInfo packed struct
         PoolKey memory poolKey;

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetSqrtPriceX96.fuzz.t.sol
@@ -36,13 +36,10 @@ contract GetSqrtPriceX96_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz
     }
 
     function testFuzz_Success_getSqrtPriceX96_Overflow(uint256 priceToken0, uint256 priceToken1) public view {
-        // Given : Avoid divide by 0, which is already checked in earlier in function.
-        priceToken1 = bound(priceToken1, 1, type(uint256).max);
-        // And : priceToken0 is max 1.158e+49, otherwise function would overflow, not realistic.
-        priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
-
-        // And : Cast to uint160 overflows (test-case).
-        vm.assume(priceToken0 / priceToken1 >= 2 ** 128);
+        // Given : Cast to uint160 overflows (test-case).
+        priceToken0 = bound(priceToken0, 2 ** 128, type(uint256).max / 1e28);
+        // And : Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1 = bound(priceToken1, 1, priceToken0 / 2 ** 128);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);
@@ -61,7 +58,7 @@ contract GetSqrtPriceX96_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz
         // And : priceToken0 is max 1.158e+49, otherwise function would overflow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // And : Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetSqrtPriceX96.fuzz.t.sol
@@ -58,7 +58,7 @@ contract GetSqrtPriceX96_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz
         // And : priceToken0 is max 1.158e+49, otherwise function would overflow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // And : Cast to uint160 will overflow, not realistic.
-        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128 - 1);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssets.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssets.fuzz.t.sol
@@ -33,7 +33,7 @@ contract GetUnderlyingAssets_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero.
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -66,7 +66,7 @@ contract GetUnderlyingAssets_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero.
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -10,13 +10,16 @@ import { DefaultUniswapV4AM_Fuzz_Test } from "./_DefaultUniswapV4AM.fuzz.t.sol";
 import { FixedPoint128 } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/FixedPoint128.sol";
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
+import {
+    LiquidityAmountsExtension
+} from "../../../utils/fixtures/uniswap-v3/extensions/libraries/LiquidityAmountsExtension.sol";
 import { PositionInfoLibrary } from "../../../../lib/v4-periphery/src/libraries/PositionInfoLibrary.sol";
 import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
 
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "DefaultUniswapV4AM".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(unsafe-typecast,divide-before-multiply)
 contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////
@@ -65,7 +68,7 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
         // And: State is valid for pool and position.
         randomPoolKey = initializePoolV4(address(token0_), address(token1_), 1e18, address(validHook), 500, 1);
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
@@ -111,7 +114,7 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
         // And: State is valid for pool and position.
         randomPoolKey = initializePoolV4(address(token0_), address(token1_), 1e18, address(validHook), 500, 1);
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
@@ -167,16 +170,25 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
         asset0.usdValue = bound(asset0.usdValue, 0, type(uint256).max / 10 ** (46 - asset0.decimals));
 
         // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
-        asset1.usdValue = bound(asset1.usdValue, 0, type(uint256).max / 10 ** (46 - asset1.decimals));
+        asset1.usdValue = bound(asset1.usdValue, 1, type(uint256).max / 10 ** (46 - asset1.decimals));
 
         // And: Cast to uint160 in _getSqrtPriceX96 does not overflow.
         if (asset1.usdValue > 0) {
-            vm.assume(asset0.usdValue / asset1.usdValue / 10 ** asset0.decimals < 2 ** 128 / 10 ** asset1.decimals);
+            uint256 maxUsdValue0 = type(uint256).max / 10 ** (46 - asset0.decimals);
+            uint256 maxRatio = 2 ** 128 / 10 ** asset1.decimals;
+            if (maxRatio < maxUsdValue0 / asset1.usdValue / 10 ** asset0.decimals) {
+                maxUsdValue0 = asset1.usdValue * maxRatio * 10 ** asset0.decimals - 1;
+            }
+            // And: sqrtPriceX96 is within the allowed range.
+            if (asset1.usdValue < 2 ** 128) {
+                uint256 ratioBound = asset1.usdValue * MAX_PRICE_RATIO;
+                if (ratioBound < maxUsdValue0) maxUsdValue0 = ratioBound;
+            }
+            asset0.usdValue = bound(asset0.usdValue, (asset1.usdValue - 1) / 10 ** 28 + 1, maxUsdValue0);
         }
 
         // Calculate and check that tick current is within allowed ranges.
         uint160 sqrtPriceX96_ = uint160(calculateAndValidateRangeTickCurrent(asset0.usdValue, asset1.usdValue));
-        vm.assume(isWithinAllowedRangeV4(TickMath.getTickAtSqrtPrice(sqrtPriceX96_)));
 
         // And: State is valid for pool and position.
         {
@@ -187,17 +199,26 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId)))
             );
 
-            vm.assume(liquidity > 0);
-            // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
+            // And: The amounts stay within the capped fee calculation and the principals do not overflow.
+            {
+                uint256 maxAmount0 = type(uint256).max / (asset0.usdValue * 10 ** (18 - asset0.decimals));
+                uint256 maxAmount1 = type(uint256).max / (asset1.usdValue * 10 ** (18 - asset1.decimals));
+                if (maxAmount0 > type(uint96).max - 1) maxAmount0 = type(uint96).max - 1;
+                if (maxAmount1 > type(uint96).max - 1) maxAmount1 = type(uint96).max - 1;
+                uint256 maxLiquidity = LiquidityAmountsExtension.getLiquidityForAmounts(
+                    sqrtPriceX96_,
+                    TickMath.getSqrtPriceAtTick(tickLower),
+                    TickMath.getSqrtPriceAtTick(tickUpper),
+                    maxAmount0,
+                    maxAmount1
+                );
+                vm.assume(maxLiquidity > 0);
+                if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
+                liquidity = uint128(bound(liquidity, 1, maxLiquidity));
+            }
             (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
                 sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
             );
-            vm.assume(amount0 < type(uint96).max);
-            vm.assume(amount1 < type(uint96).max);
-
-            // And: principals do not overflow.
-            vm.assume(amount0 < type(uint256).max / (asset0.usdValue * 10 ** (18 - asset0.decimals)));
-            vm.assume(amount1 < type(uint256).max / (asset1.usdValue * 10 ** (18 - asset1.decimals)));
 
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);
@@ -250,16 +271,25 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
         asset0.usdValue = bound(asset0.usdValue, 0, type(uint256).max / 10 ** (46 - asset0.decimals));
 
         // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
-        asset1.usdValue = bound(asset1.usdValue, 0, type(uint256).max / 10 ** (46 - asset1.decimals));
+        asset1.usdValue = bound(asset1.usdValue, 1, type(uint256).max / 10 ** (46 - asset1.decimals));
 
         // And: Cast to uint160 in _getSqrtPriceX96 does not overflow.
         if (asset1.usdValue > 0) {
-            vm.assume(asset0.usdValue / asset1.usdValue / 10 ** asset0.decimals < 2 ** 128 / 10 ** asset1.decimals);
+            uint256 maxUsdValue0 = type(uint256).max / 10 ** (46 - asset0.decimals);
+            uint256 maxRatio = 2 ** 128 / 10 ** asset1.decimals;
+            if (maxRatio < maxUsdValue0 / asset1.usdValue / 10 ** asset0.decimals) {
+                maxUsdValue0 = asset1.usdValue * maxRatio * 10 ** asset0.decimals - 1;
+            }
+            // And: sqrtPriceX96 is within the allowed range.
+            if (asset1.usdValue < 2 ** 128) {
+                uint256 ratioBound = asset1.usdValue * MAX_PRICE_RATIO;
+                if (ratioBound < maxUsdValue0) maxUsdValue0 = ratioBound;
+            }
+            asset0.usdValue = bound(asset0.usdValue, (asset1.usdValue - 1) / 10 ** 28 + 1, maxUsdValue0);
         }
 
         // Calculate and check that tick current is within allowed ranges.
         uint160 sqrtPriceX96_ = uint160(calculateAndValidateRangeTickCurrent(asset0.usdValue, asset1.usdValue));
-        vm.assume(isWithinAllowedRangeV4(TickMath.getTickAtSqrtPrice(sqrtPriceX96_)));
 
         // And: State is valid for pool and position.
         {
@@ -269,17 +299,26 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId)))
             );
 
-            vm.assume(liquidity > 0);
-            // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
+            // And: The amounts stay within the capped fee calculation and the principals do not overflow.
+            {
+                uint256 maxAmount0 = type(uint256).max / (asset0.usdValue * 10 ** (18 - asset0.decimals));
+                uint256 maxAmount1 = type(uint256).max / (asset1.usdValue * 10 ** (18 - asset1.decimals));
+                if (maxAmount0 > type(uint96).max - 1) maxAmount0 = type(uint96).max - 1;
+                if (maxAmount1 > type(uint96).max - 1) maxAmount1 = type(uint96).max - 1;
+                uint256 maxLiquidity = LiquidityAmountsExtension.getLiquidityForAmounts(
+                    sqrtPriceX96_,
+                    TickMath.getSqrtPriceAtTick(tickLower),
+                    TickMath.getSqrtPriceAtTick(tickUpper),
+                    maxAmount0,
+                    maxAmount1
+                );
+                vm.assume(maxLiquidity > 0);
+                if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
+                liquidity = uint128(bound(liquidity, 1, maxLiquidity));
+            }
             (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
                 sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
             );
-            vm.assume(amount0 < type(uint96).max);
-            vm.assume(amount1 < type(uint96).max);
-
-            // And: principals do not overflow.
-            vm.assume(amount0 < type(uint256).max / (asset0.usdValue * 10 ** (18 - asset0.decimals)));
-            vm.assume(amount1 < type(uint256).max / (asset1.usdValue * 10 ** (18 - asset1.decimals)));
 
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);
@@ -338,17 +377,28 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
         asset0.usdValue = bound(asset0.usdValue, 0, type(uint128).max / 10 ** (46 - asset0.decimals));
 
         // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
-        asset1.usdValue = bound(asset1.usdValue, 0, type(uint128).max / 10 ** (46 - asset1.decimals));
+        uint256 maxUsdValue1 = type(uint128).max / 10 ** (46 - asset1.decimals);
+        vm.assume(maxUsdValue1 > 0);
+        asset1.usdValue = bound(asset1.usdValue, 1, maxUsdValue1);
 
         // And: Cast to uint160 in _getSqrtPriceX96 does not overflow.
         if (asset1.usdValue > 0) {
-            vm.assume(asset0.usdValue / asset1.usdValue / 10 ** asset0.decimals < 2 ** 128 / 10 ** asset1.decimals);
+            uint256 maxUsdValue0 = type(uint256).max / 10 ** (46 - asset0.decimals);
+            uint256 maxRatio = 2 ** 128 / 10 ** asset1.decimals;
+            if (maxRatio < maxUsdValue0 / asset1.usdValue / 10 ** asset0.decimals) {
+                maxUsdValue0 = asset1.usdValue * maxRatio * 10 ** asset0.decimals - 1;
+            }
+            // And: sqrtPriceX96 is within the allowed range.
+            if (asset1.usdValue < 2 ** 128) {
+                uint256 ratioBound = asset1.usdValue * MAX_PRICE_RATIO;
+                if (ratioBound < maxUsdValue0) maxUsdValue0 = ratioBound;
+            }
+            asset0.usdValue = bound(asset0.usdValue, (asset1.usdValue - 1) / 10 ** 28 + 1, maxUsdValue0);
         }
 
         // Calculate and check that tick current is within allowed ranges.
         {
             uint160 sqrtPriceX96_ = uint160(calculateAndValidateRangeTickCurrent(asset0.usdValue, asset1.usdValue));
-            vm.assume(isWithinAllowedRangeV4(TickMath.getTickAtSqrtPrice(sqrtPriceX96_)));
 
             // And: State is valid for pool and position.
             randomPoolKey =
@@ -358,13 +408,22 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId)))
             );
 
-            vm.assume(liquidity > 0);
-            // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
+            // And: The amounts stay within the capped fee calculation.
+            {
+                uint256 maxLiquidity = LiquidityAmountsExtension.getLiquidityForAmounts(
+                    sqrtPriceX96_,
+                    TickMath.getSqrtPriceAtTick(tickLower),
+                    TickMath.getSqrtPriceAtTick(tickUpper),
+                    type(uint96).max - 1,
+                    type(uint96).max - 1
+                );
+                vm.assume(maxLiquidity > 0);
+                if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
+                liquidity = uint128(bound(liquidity, 1, maxLiquidity));
+            }
             (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
                 sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
             );
-            vm.assume(amount0 < type(uint96).max);
-            vm.assume(amount1 < type(uint96).max);
 
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);
@@ -406,7 +465,7 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
             }
 
             {
-                vm.assume(feeData.desiredFee1 <= type(uint256).max / FixedPoint128.Q128);
+                feeData.desiredFee1 = bound(feeData.desiredFee1, 0, type(uint256).max / FixedPoint128.Q128);
                 uint256 feeGrowthDiff1X128 = feeData.desiredFee1.mulDivDown(FixedPoint128.Q128, liquidity);
                 feeData.upperFeeGrowthOutside1X128 =
                     bound(feeData.upperFeeGrowthOutside1X128, 0, type(uint256).max - feeGrowthDiff1X128);
@@ -470,17 +529,28 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
         asset0.usdValue = bound(asset0.usdValue, 0, type(uint128).max / 10 ** (46 - asset0.decimals));
 
         // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
-        asset1.usdValue = bound(asset1.usdValue, 0, type(uint128).max / 10 ** (46 - asset1.decimals));
+        uint256 maxUsdValue1 = type(uint128).max / 10 ** (46 - asset1.decimals);
+        vm.assume(maxUsdValue1 > 0);
+        asset1.usdValue = bound(asset1.usdValue, 1, maxUsdValue1);
 
         // And: Cast to uint160 in _getSqrtPriceX96 does not overflow.
         if (asset1.usdValue > 0) {
-            vm.assume(asset0.usdValue / asset1.usdValue / 10 ** asset0.decimals < 2 ** 128 / 10 ** asset1.decimals);
+            uint256 maxUsdValue0 = type(uint256).max / 10 ** (46 - asset0.decimals);
+            uint256 maxRatio = 2 ** 128 / 10 ** asset1.decimals;
+            if (maxRatio < maxUsdValue0 / asset1.usdValue / 10 ** asset0.decimals) {
+                maxUsdValue0 = asset1.usdValue * maxRatio * 10 ** asset0.decimals - 1;
+            }
+            // And: sqrtPriceX96 is within the allowed range.
+            if (asset1.usdValue < 2 ** 128) {
+                uint256 ratioBound = asset1.usdValue * MAX_PRICE_RATIO;
+                if (ratioBound < maxUsdValue0) maxUsdValue0 = ratioBound;
+            }
+            asset0.usdValue = bound(asset0.usdValue, (asset1.usdValue - 1) / 10 ** 28 + 1, maxUsdValue0);
         }
 
         // Calculate and check that tick current is within allowed ranges.
         {
             uint160 sqrtPriceX96_ = uint160(calculateAndValidateRangeTickCurrent(asset0.usdValue, asset1.usdValue));
-            vm.assume(isWithinAllowedRangeV4(TickMath.getTickAtSqrtPrice(sqrtPriceX96_)));
 
             // And: State is valid for pool and position.
             randomPoolKey =
@@ -490,13 +560,22 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId)))
             );
 
-            vm.assume(liquidity > 0);
-            // And: No overflow in capped fee calculation (max fee that can be considered as underlying amount to avoid bypassing max exposure)
+            // And: The amounts stay within the capped fee calculation.
+            {
+                uint256 maxLiquidity = LiquidityAmountsExtension.getLiquidityForAmounts(
+                    sqrtPriceX96_,
+                    TickMath.getSqrtPriceAtTick(tickLower),
+                    TickMath.getSqrtPriceAtTick(tickUpper),
+                    type(uint96).max - 1,
+                    type(uint96).max - 1
+                );
+                vm.assume(maxLiquidity > 0);
+                if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
+                liquidity = uint128(bound(liquidity, 1, maxLiquidity));
+            }
             (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
                 sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
             );
-            vm.assume(amount0 < type(uint96).max);
-            vm.assume(amount1 < type(uint96).max);
 
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -5,8 +5,8 @@
 pragma solidity ^0.8.0;
 
 import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
-import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
 import { DefaultUniswapV4AM_Fuzz_Test } from "./_DefaultUniswapV4AM.fuzz.t.sol";
+import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
 import { FixedPoint128 } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/FixedPoint128.sol";
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -216,10 +216,6 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
                 liquidity = uint128(bound(liquidity, 1, maxLiquidity));
             }
-            (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
-                sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
-            );
-
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);
         }
@@ -316,10 +312,6 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
                 liquidity = uint128(bound(liquidity, 1, maxLiquidity));
             }
-            (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
-                sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
-            );
-
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);
         }
@@ -421,10 +413,6 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
                 liquidity = uint128(bound(liquidity, 1, maxLiquidity));
             }
-            (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
-                sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
-            );
-
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);
         }
@@ -573,10 +561,6 @@ contract GetUnderlyingAssetsAmounts_DefaultUniswapV4AM_Fuzz_Test is DefaultUnisw
                 if (maxLiquidity > type(uint128).max) maxLiquidity = type(uint128).max;
                 liquidity = uint128(bound(liquidity, 1, maxLiquidity));
             }
-            (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
-                sqrtPriceX96_, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
-            );
-
             poolManager.setPositionLiquidity(randomPoolKey.toId(), positionKey, liquidity);
             positionManagerV4.setPosition(users.owner, randomPoolKey, tickLower, tickUpper, tokenId);
         }

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/GetValue.fuzz.t.sol
@@ -47,16 +47,14 @@ contract GetValue_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
         vm.stopPrank();
 
         // And : Avoid divide by 0 in next line.
-        vm.assume(vars.priceToken1 > 0);
-        // And : Cast to uint160 will overflow, not realistic.
-        vm.assume(vars.priceToken0 / vars.priceToken1 < 2 ** 128);
-        // Check that sqrtPriceX96 is within allowed Uniswap V4 ranges.
+        vars.priceToken1 = uint64(bound(vars.priceToken1, 1, type(uint64).max));
+        // And : sqrtPriceX96 is within the allowed Uniswap V4 range.
+        uint256 minPriceToken0 = (vars.priceToken1 * 10 ** (18 - vars.decimals1) - 1) / 10 ** 28 + 1;
+        vars.priceToken0 =
+            uint64(bound(vars.priceToken0, (minPriceToken0 - 1) / 10 ** (18 - vars.decimals0) + 1, type(uint64).max));
         uint160 sqrtPriceX96 = uniswapV4AM.getSqrtPriceX96(
             vars.priceToken0 * 10 ** (18 - vars.decimals0), vars.priceToken1 * 10 ** (18 - vars.decimals1)
         );
-
-        vm.assume(sqrtPriceX96 >= MIN_SQRT_PRICE);
-        vm.assume(sqrtPriceX96 <= MAX_SQRT_PRICE);
 
         // And : Initialize Uniswap V4 pool initiated at tickCurrent with tickSpacing = 1.
         int24 tickSpacing = 1;
@@ -124,16 +122,14 @@ contract GetValue_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
         ERC20 token1_ = new ERC20Mock("TOKEN1", "TOK1", uint8(vars.decimals1));
 
         // And : Avoid divide by 0 in next line.
-        vm.assume(vars.priceToken1 > 0);
-        // And : Cast to uint160 will overflow, not realistic.
-        vm.assume(vars.priceToken0 / vars.priceToken1 < 2 ** 128);
-        // Check that sqrtPriceX96 is within allowed Uniswap V4 ranges.
+        vars.priceToken1 = uint64(bound(vars.priceToken1, 1, type(uint64).max));
+        // And : sqrtPriceX96 is within the allowed Uniswap V4 range.
+        uint256 minPriceToken0 = (vars.priceToken1 * 10 ** (18 - vars.decimals1) - 1) / 10 ** 28 + 1;
+        vars.priceToken0 =
+            uint64(bound(vars.priceToken0, (minPriceToken0 - 1) / 10 ** (18 - vars.decimals0) + 1, type(uint64).max));
         uint160 sqrtPriceX96 = uniswapV4AM.getSqrtPriceX96(
             vars.priceToken0 * 10 ** (18 - vars.decimals0), vars.priceToken1 * 10 ** (18 - vars.decimals1)
         );
-
-        vm.assume(sqrtPriceX96 >= MIN_SQRT_PRICE);
-        vm.assume(sqrtPriceX96 <= MAX_SQRT_PRICE);
 
         // And : Initialize Uniswap V4 pool initiated at tickCurrent with tickSpacing = 1.
         int24 tickSpacing = 1;

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/IsAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/IsAllowed.fuzz.t.sol
@@ -10,6 +10,7 @@ import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries
 /**
  * @notice Fuzz tests for the function "isAllowed" of contract "DefaultUniswapV4AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IsAllowed_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -52,7 +53,7 @@ contract IsAllowed_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test 
         );
 
         // And: Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -84,7 +85,7 @@ contract IsAllowed_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test 
         );
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -115,7 +116,7 @@ contract IsAllowed_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test 
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -132,7 +133,7 @@ contract IsAllowed_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM_Fuzz_Test 
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(nativeTokenPoolKey.toId(), positionKey, liquidity);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectDeposit.fuzz.t.sol
@@ -38,6 +38,7 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint256 priceToken0,
         uint256 priceToken1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         vm.assume(unprivilegedAddress != address(v4HooksRegistry));
 
         // Given : Valid state
@@ -78,6 +79,7 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint112 initialExposure0,
         uint112 maxExposure0
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state, with position fully in token0 (amount0 needed in this test case)
         (uint256 tokenId, uint256 amount0,,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 2);
@@ -109,6 +111,7 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint112 initialExposure1,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state, with position fully in token0 (amount0 needed in this test case)
         (uint256 tokenId,, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 1);
@@ -141,17 +144,16 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 < type(uint112).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 < type(uint112).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint112).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint112).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -161,8 +163,13 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
             // And: usd exposure to protocol below max usd exposure.
             (uint256 usdExposureProtocol,,) =
                 uniswapV4AM.getValue(address(creditorUsd), address(positionManagerV4), tokenId, 1);
-            vm.assume(usdExposureProtocol < type(uint112).max);
-            maxUsdExposureProtocol = uint112(bound(maxUsdExposureProtocol, 0, usdExposureProtocol));
+            maxUsdExposureProtocol = uint112(
+                bound(
+                    maxUsdExposureProtocol,
+                    0,
+                    usdExposureProtocol < type(uint112).max ? usdExposureProtocol : type(uint112).max
+                )
+            );
         }
 
         vm.prank(users.riskManager);
@@ -188,17 +195,16 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // And : Exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -257,17 +263,16 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -328,17 +333,16 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -397,6 +401,7 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Token0 is a native token.
         token0 = ERC20Mock(address(0));
 
@@ -405,12 +410,10 @@ contract ProcessDirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4AM
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // And : Exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addNativeTokenToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessDirectWithdrawal.fuzz.t.sol
@@ -55,17 +55,16 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -122,17 +121,16 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -186,17 +184,16 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -253,6 +250,7 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Token0 is a native token.
         token0 = ERC20Mock(address(0));
 
@@ -261,12 +259,10 @@ contract ProcessDirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addNativeTokenToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -38,6 +38,7 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
         uint256 priceToken1,
         uint256 exposureUpperAssetToAsset
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         vm.assume(unprivilegedAddress != address(v4HooksRegistry));
 
         // Given : Valid state
@@ -60,9 +61,9 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
         uint256 exposureUpperAssetToAsset,
         int256 amount
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Amount not equal to 0 or 1
-        vm.assume(amount != 0);
-        vm.assume(amount != 1);
+        vm.assume(amount != 0 && amount != 1);
 
         // And : Valid state
         (uint256 tokenId,,,) = givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
@@ -88,17 +89,16 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given: Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // And:  exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // And: Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -157,17 +157,16 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -228,17 +227,16 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd exposure of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -295,6 +293,7 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Token0 is a native token.
         token0 = ERC20Mock(address(0));
 
@@ -303,12 +302,10 @@ contract ProcessIndirectDeposit_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswapV4
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // And:  exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // And: Add underlying tokens and its oracles to Arcadia.
         addNativeTokenToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -58,17 +58,16 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -126,17 +125,16 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -193,17 +191,16 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -259,6 +256,7 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Token0 is a native token.
         token0 = ERC20Mock(address(0));
 
@@ -267,12 +265,10 @@ contract ProcessIndirectWithdrawal_DefaultUniswapV4AM_Fuzz_Test is DefaultUniswa
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addNativeTokenToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
@@ -37,8 +37,7 @@ abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
     ERC20 token1;
 
     uint256 internal constant INT256_MAX = 2 ** 255 - 1;
-    // While the true minimum value of an int256 is 2 ** 255, Solidity overflows on a negation (since INT256_MAX is one less).
-    // -> This true minimum value will overflow and revert.
+    // Negating the true minimum of 2 ** 255 overflows, so this stops one below it.
     uint256 internal constant INT256_MIN = 2 ** 255 - 1;
 
     /* ///////////////////////////////////////////////////////////////
@@ -202,7 +201,9 @@ abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
             // And : Liquidity is within range
             uint256 maxLiquidity = getLiquidityDeltaFromAmounts(tickLower, tickUpper, sqrtPriceX96);
             uint256 maxTickLiquidity = poolManager.getTickSpacingToMaxLiquidityPerTick(1);
-            liquidity = bound(liquidity, 1, maxLiquidity < maxTickLiquidity ? maxLiquidity : maxTickLiquidity);
+            if (maxLiquidity > maxTickLiquidity) maxLiquidity = maxTickLiquidity;
+            vm.assume(maxLiquidity > 0);
+            liquidity = bound(liquidity, 1, maxLiquidity);
         }
 
         // Create Uniswap V4 pool initiated at tickCurrent with fee 500 and tickSpacing 1.

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
@@ -124,20 +124,9 @@ abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
         pure
         returns (uint256 sqrtPriceX96)
     {
-        // Avoid divide by 0, which is already checked in earlier in function.
-        vm.assume(priceToken1 > 0);
-        // Function will overFlow, not realistic.
-        vm.assume(priceToken0 <= type(uint256).max / 10 ** 28);
-        vm.assume(priceToken1 <= type(uint256).max / 10 ** 18);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
-
-        // sqrtPriceX96 must be within ranges, or TickMath reverts.
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);
         sqrtPriceX96 = sqrtPriceXd14 * 2 ** 96 / 1e14;
-        vm.assume(sqrtPriceX96 >= MIN_SQRT_PRICE);
-        vm.assume(sqrtPriceX96 <= MAX_SQRT_PRICE);
     }
 
     function givenValidTicks(int24 tickLower, int24 tickUpper)
@@ -145,8 +134,8 @@ abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
         pure
         returns (int24 tickLower_, int24 tickUpper_)
     {
-        tickLower_ = int24(bound(tickLower, MIN_TICK, MAX_TICK - 2));
-        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, MAX_TICK));
+        tickLower_ = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
+        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, TickMath.MAX_TICK));
     }
 
     // From UniV4-core tests
@@ -193,19 +182,17 @@ abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
         int24 currentTick = TickMath.getTickAtSqrtPrice(sqrtPriceX96);
 
-        vm.assume(isWithinAllowedRangeV4(currentTick));
-
         // And : Valid ticks
         if (outOfRange == 1) {
             // Position should be fully in token 1
-            vm.assume(currentTick > MIN_TICK + 2);
-            tickUpper = int24(bound(tickUpper, MIN_TICK + 2, currentTick));
-            tickLower = int24(bound(tickLower, MIN_TICK, tickUpper - 1));
+            vm.assume(currentTick > TickMath.MIN_TICK + 2);
+            tickUpper = int24(bound(tickUpper, TickMath.MIN_TICK + 2, currentTick));
+            tickLower = int24(bound(tickLower, TickMath.MIN_TICK, tickUpper - 1));
         } else if (outOfRange == 2) {
             // Position should be fully in token 0
-            vm.assume(currentTick < MAX_TICK - 2);
-            tickLower = int24(bound(tickLower, currentTick + 1, MAX_TICK - 2));
-            tickUpper = int24(bound(tickUpper, tickLower + 1, MAX_TICK));
+            vm.assume(currentTick < TickMath.MAX_TICK - 2);
+            tickLower = int24(bound(tickLower, currentTick + 1, TickMath.MAX_TICK - 2));
+            tickUpper = int24(bound(tickUpper, tickLower + 1, TickMath.MAX_TICK));
         } else {
             // Ticks between min and max tick
             (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
@@ -214,8 +201,8 @@ abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
         {
             // And : Liquidity is within range
             uint256 maxLiquidity = getLiquidityDeltaFromAmounts(tickLower, tickUpper, sqrtPriceX96);
-            liquidity = bound(liquidity, 1, maxLiquidity);
-            vm.assume(liquidity <= poolManager.getTickSpacingToMaxLiquidityPerTick(1));
+            uint256 maxTickLiquidity = poolManager.getTickSpacingToMaxLiquidityPerTick(1);
+            liquidity = bound(liquidity, 1, maxLiquidity < maxTickLiquidity ? maxLiquidity : maxTickLiquidity);
         }
 
         // Create Uniswap V4 pool initiated at tickCurrent with fee 500 and tickSpacing 1.

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
@@ -128,15 +128,6 @@ abstract contract DefaultUniswapV4AM_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
         sqrtPriceX96 = sqrtPriceXd14 * 2 ** 96 / 1e14;
     }
 
-    function givenValidTicks(int24 tickLower, int24 tickUpper)
-        public
-        pure
-        returns (int24 tickLower_, int24 tickUpper_)
-    {
-        tickLower_ = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
-        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, TickMath.MAX_TICK));
-    }
-
     // From UniV4-core tests
     function getLiquidityDeltaFromAmounts(int24 tickLower, int24 tickUpper, uint160 sqrtPriceX96)
         public

--- a/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/DefaultUniswapV4AM/_DefaultUniswapV4AM.fuzz.t.sol
@@ -6,8 +6,8 @@ pragma solidity ^0.8.0;
 
 import { DefaultUniswapV4AMExtension } from "../../../../test/utils/extensions/DefaultUniswapV4AMExtension.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
-import { Fuzz_Test } from "../../Fuzz.t.sol";
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
+import { Fuzz_Test } from "../../Fuzz.t.sol";
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import {
     LiquidityAmountsExtension

--- a/test/fuzz/asset-modules/ERC20PrimaryAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/ERC20PrimaryAM/AddAsset.fuzz.t.sol
@@ -4,13 +4,11 @@
  */
 pragma solidity ^0.8.0;
 
-import { ERC20PrimaryAM_Fuzz_Test } from "./_ERC20PrimaryAM.fuzz.t.sol";
-
 import { ArcadiaOracle } from "../../../utils/mocks/oracles/ArcadiaOracle.sol";
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
-
 import { Constants } from "../../../utils/Constants.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
+import { ERC20PrimaryAM_Fuzz_Test } from "./_ERC20PrimaryAM.fuzz.t.sol";
 import { PrimaryAM, ERC20PrimaryAM } from "../../../../src/asset-modules/ERC20-Primaries/ERC20PrimaryAM.sol";
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 

--- a/test/fuzz/asset-modules/ERC20PrimaryAM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/ERC20PrimaryAM/GetValue.fuzz.t.sol
@@ -4,9 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { ERC20PrimaryAM_Fuzz_Test } from "./_ERC20PrimaryAM.fuzz.t.sol";
-
 import { Constants } from "../../../utils/Constants.sol";
+import { ERC20PrimaryAM_Fuzz_Test } from "./_ERC20PrimaryAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getValue" of contract "ERC20PrimaryAM".

--- a/test/fuzz/asset-modules/FloorERC1155AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/AddAsset.fuzz.t.sol
@@ -4,9 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { FloorERC1155AM_Fuzz_Test } from "./_FloorERC1155AM.fuzz.t.sol";
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { FloorERC1155AM } from "../../../utils/mocks/asset-modules/FloorERC1155AM.sol";
+import { FloorERC1155AM_Fuzz_Test } from "./_FloorERC1155AM.fuzz.t.sol";
 import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrimaryAM.sol";
 
 /**

--- a/test/fuzz/asset-modules/FloorERC1155AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/GetValue.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { FloorERC1155AM_Fuzz_Test } from "./_FloorERC1155AM.fuzz.t.sol";
 import { Constants } from "../../../utils/Constants.sol";
+import { FloorERC1155AM_Fuzz_Test } from "./_FloorERC1155AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getValue" of contract "FloorERC1155AM".

--- a/test/fuzz/asset-modules/FloorERC1155AM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/ProcessDirectDeposit.fuzz.t.sol
@@ -41,8 +41,8 @@ contract ProcessDirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_Te
     }
 
     function testFuzz_Revert_processDirectDeposit_OverExposure(uint128 amount, uint112 maxExposure) public {
-        vm.assume(maxExposure > 0); //Asset is allowed
-        vm.assume(amount >= maxExposure);
+        maxExposure = uint112(bound(maxExposure, 1, type(uint112).max));
+        amount = uint128(bound(amount, maxExposure, type(uint128).max));
         vm.prank(users.owner);
         floorERC1155AM.addAsset(address(mockERC1155.sft2), 1, oraclesSft2ToUsd);
         vm.prank(users.riskManager);
@@ -55,7 +55,7 @@ contract ProcessDirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_Te
     }
 
     function testFuzz_Revert_processDirectDeposit_WrongID(uint96 assetId, uint128 amount) public {
-        vm.assume(assetId > 0); //Wrong Id
+        assetId = uint96(bound(assetId, 1, type(uint96).max));
         vm.prank(users.owner);
         floorERC1155AM.addAsset(address(mockERC1155.sft2), 0, oraclesSft2ToUsd);
 

--- a/test/fuzz/asset-modules/FloorERC1155AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -47,7 +47,7 @@ contract ProcessIndirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_
         uint256 exposureUpperAssetToAsset,
         int256 deltaExposureUpperAssetToAsset
     ) public {
-        vm.assume(assetId > 0); //Wrong Id
+        assetId = uint96(bound(assetId, 1, type(uint96).max));
         vm.prank(users.owner);
         floorERC1155AM.addAsset(address(mockERC1155.sft2), 0, oraclesSft2ToUsd);
 
@@ -64,10 +64,12 @@ contract ProcessIndirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_
         int256 deltaExposureUpperAssetToAsset,
         uint112 maxExposure
     ) public {
-        vm.assume(deltaExposureUpperAssetToAsset > 0);
-        vm.assume(uint256(deltaExposureUpperAssetToAsset) < maxExposure);
+        deltaExposureUpperAssetToAsset = bound(
+            deltaExposureUpperAssetToAsset, 1, int256(uint256(type(uint112).max)) - 1
+        );
+        maxExposure = uint112(bound(maxExposure, uint256(deltaExposureUpperAssetToAsset) + 1, type(uint112).max));
         // To avoid overflow when calculating "usdExposureUpperAssetToAsset"
-        vm.assume(exposureUpperAssetToAsset < type(uint112).max);
+        exposureUpperAssetToAsset = bound(exposureUpperAssetToAsset, 0, type(uint112).max - 1);
 
         vm.prank(users.owner);
         floorERC1155AM.addAsset(address(mockERC1155.sft2), 0, oraclesSft2ToUsd);
@@ -76,7 +78,11 @@ contract ProcessIndirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_
 
         (uint256 actualValueInUsd,,) = floorERC1155AM.getValue(address(creditorUsd), address(mockERC1155.sft2), 0, 1);
 
-        vm.assume(actualValueInUsd * exposureUpperAssetToAsset < type(uint256).max);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            actualValueInUsd == 0 ? type(uint256).max : type(uint256).max / actualValueInUsd
+        );
 
         vm.prank(address(registry));
         (uint256 recursiveCalls, uint256 usdExposureUpperAssetToAsset) = floorERC1155AM.processIndirectDeposit(
@@ -119,7 +125,11 @@ contract ProcessIndirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_
 
         (uint256 actualValueInUsd,,) = floorERC1155AM.getValue(address(creditorUsd), address(mockERC1155.sft2), 0, 1);
 
-        vm.assume(actualValueInUsd * exposureUpperAssetToAsset < type(uint256).max);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            actualValueInUsd == 0 ? type(uint256).max : type(uint256).max / actualValueInUsd
+        );
 
         vm.prank(address(registry));
         (uint256 recursiveCalls, uint256 usdExposureUpperAssetToAsset) = floorERC1155AM.processIndirectDeposit(
@@ -163,7 +173,11 @@ contract ProcessIndirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_
 
         (uint256 actualValueInUsd,,) = floorERC1155AM.getValue(address(creditorUsd), address(mockERC1155.sft2), 0, 1);
 
-        vm.assume(actualValueInUsd * exposureUpperAssetToAsset < type(uint256).max);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            actualValueInUsd == 0 ? type(uint256).max : type(uint256).max / actualValueInUsd
+        );
 
         vm.prank(address(registry));
         (uint256 recursiveCalls, uint256 usdExposureUpperAssetToAsset) = floorERC1155AM.processIndirectDeposit(

--- a/test/fuzz/asset-modules/FloorERC1155AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -11,6 +11,7 @@ import { FloorERC1155AM_Fuzz_Test } from "./_FloorERC1155AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "processIndirectDeposit" of contract "FloorERC1155AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ProcessIndirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -58,5 +59,128 @@ contract ProcessIndirectDeposit_FloorERC1155AM_Fuzz_Test is FloorERC1155AM_Fuzz_
         vm.stopPrank();
     }
 
-    //todo: add success tests
+    function testFuzz_Success_processIndirectDeposit_positiveDelta(
+        uint256 exposureUpperAssetToAsset,
+        int256 deltaExposureUpperAssetToAsset,
+        uint112 maxExposure
+    ) public {
+        vm.assume(deltaExposureUpperAssetToAsset > 0);
+        vm.assume(uint256(deltaExposureUpperAssetToAsset) < maxExposure);
+        // To avoid overflow when calculating "usdExposureUpperAssetToAsset"
+        vm.assume(exposureUpperAssetToAsset < type(uint112).max);
+
+        vm.prank(users.owner);
+        floorERC1155AM.addAsset(address(mockERC1155.sft2), 0, oraclesSft2ToUsd);
+        vm.prank(users.riskManager);
+        registry.setRiskParametersOfPrimaryAsset(address(creditorUsd), address(mockERC1155.sft2), 0, maxExposure, 0, 0);
+
+        (uint256 actualValueInUsd,,) = floorERC1155AM.getValue(address(creditorUsd), address(mockERC1155.sft2), 0, 1);
+
+        vm.assume(actualValueInUsd * exposureUpperAssetToAsset < type(uint256).max);
+
+        vm.prank(address(registry));
+        (uint256 recursiveCalls, uint256 usdExposureUpperAssetToAsset) = floorERC1155AM.processIndirectDeposit(
+            address(creditorUsd),
+            address(mockERC1155.sft2),
+            0,
+            exposureUpperAssetToAsset,
+            deltaExposureUpperAssetToAsset
+        );
+
+        uint256 expectedUsdValueExposureUpperAssetToAsset = actualValueInUsd * exposureUpperAssetToAsset;
+        assertEq(recursiveCalls, 1);
+        assertEq(usdExposureUpperAssetToAsset, expectedUsdValueExposureUpperAssetToAsset);
+
+        bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(mockERC1155.sft2)));
+        (uint128 actualExposure,,,) = floorERC1155AM.riskParams(address(creditorUsd), assetKey);
+        assertEq(actualExposure, uint256(deltaExposureUpperAssetToAsset));
+    }
+
+    function testFuzz_Success_processIndirectDeposit_negativeDelta_NoUnderflow(
+        uint256 exposureUpperAssetToAsset,
+        uint256 initialExposure,
+        uint256 deltaExposureUpperAssetToAsset
+    ) public {
+        initialExposure = bound(initialExposure, 1, type(uint112).max - 1);
+        deltaExposureUpperAssetToAsset = bound(deltaExposureUpperAssetToAsset, 1, initialExposure);
+
+        // To avoid overflow when calculating "usdExposureUpperAssetToAsset"
+        exposureUpperAssetToAsset = bound(exposureUpperAssetToAsset, 0, type(uint112).max);
+
+        vm.prank(users.owner);
+        floorERC1155AM.addAsset(address(mockERC1155.sft2), 0, oraclesSft2ToUsd);
+        vm.prank(users.riskManager);
+        registry.setRiskParametersOfPrimaryAsset(
+            address(creditorUsd), address(mockERC1155.sft2), 0, type(uint112).max, 0, 0
+        );
+
+        vm.prank(address(registry));
+        floorERC1155AM.processDirectDeposit(address(creditorUsd), address(mockERC1155.sft2), 0, initialExposure);
+
+        (uint256 actualValueInUsd,,) = floorERC1155AM.getValue(address(creditorUsd), address(mockERC1155.sft2), 0, 1);
+
+        vm.assume(actualValueInUsd * exposureUpperAssetToAsset < type(uint256).max);
+
+        vm.prank(address(registry));
+        (uint256 recursiveCalls, uint256 usdExposureUpperAssetToAsset) = floorERC1155AM.processIndirectDeposit(
+            address(creditorUsd),
+            address(mockERC1155.sft2),
+            0,
+            exposureUpperAssetToAsset,
+            -int256(deltaExposureUpperAssetToAsset)
+        );
+
+        uint256 expectedUsdValueExposureUpperAssetToAsset = actualValueInUsd * exposureUpperAssetToAsset;
+        assertEq(recursiveCalls, 1);
+        assertEq(usdExposureUpperAssetToAsset, expectedUsdValueExposureUpperAssetToAsset);
+
+        bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(mockERC1155.sft2)));
+        (uint128 actualExposure,,,) = floorERC1155AM.riskParams(address(creditorUsd), assetKey);
+        assertEq(actualExposure, initialExposure - deltaExposureUpperAssetToAsset);
+    }
+
+    function testFuzz_Success_processIndirectDeposit_negativeDelta_Underflow(
+        uint256 exposureUpperAssetToAsset,
+        uint256 initialExposure,
+        uint256 deltaExposureUpperAssetToAsset
+    ) public {
+        initialExposure = bound(initialExposure, 1, type(uint112).max - 1);
+        deltaExposureUpperAssetToAsset =
+            bound(deltaExposureUpperAssetToAsset, initialExposure + 1, uint256(type(int256).max));
+
+        // To avoid overflow when calculating "usdExposureUpperAssetToAsset"
+        exposureUpperAssetToAsset = bound(exposureUpperAssetToAsset, 0, type(uint112).max);
+
+        vm.prank(users.owner);
+        floorERC1155AM.addAsset(address(mockERC1155.sft2), 0, oraclesSft2ToUsd);
+        vm.prank(users.riskManager);
+        registry.setRiskParametersOfPrimaryAsset(
+            address(creditorUsd), address(mockERC1155.sft2), 0, type(uint112).max, 0, 0
+        );
+
+        vm.prank(address(registry));
+        floorERC1155AM.processDirectDeposit(address(creditorUsd), address(mockERC1155.sft2), 0, initialExposure);
+
+        (uint256 actualValueInUsd,,) = floorERC1155AM.getValue(address(creditorUsd), address(mockERC1155.sft2), 0, 1);
+
+        vm.assume(actualValueInUsd * exposureUpperAssetToAsset < type(uint256).max);
+
+        vm.prank(address(registry));
+        (uint256 recursiveCalls, uint256 usdExposureUpperAssetToAsset) = floorERC1155AM.processIndirectDeposit(
+            address(creditorUsd),
+            address(mockERC1155.sft2),
+            0,
+            exposureUpperAssetToAsset,
+            -int256(deltaExposureUpperAssetToAsset)
+        );
+
+        uint256 expectedUsdValueExposureUpperAssetToAsset = actualValueInUsd * exposureUpperAssetToAsset;
+        assertEq(recursiveCalls, 1);
+        assertEq(usdExposureUpperAssetToAsset, expectedUsdValueExposureUpperAssetToAsset);
+
+        // And: Exposure is set to zero instead of underflowing.
+        bytes32 assetKey = bytes32(abi.encodePacked(uint96(0), address(mockERC1155.sft2)));
+        (uint128 actualExposure,,,) = floorERC1155AM.riskParams(address(creditorUsd), assetKey);
+        assertEq(actualExposure, 0);
+    }
 }

--- a/test/fuzz/asset-modules/FloorERC1155AM/_FloorERC1155AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC1155AM/_FloorERC1155AM.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { Fuzz_Test } from "../../Fuzz.t.sol";
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
+import { Fuzz_Test } from "../../Fuzz.t.sol";
 
 /**
  * @notice Common logic needed by all "FloorERC1155AM" fuzz tests.

--- a/test/fuzz/asset-modules/FloorERC721AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/AddAsset.fuzz.t.sol
@@ -4,10 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { FloorERC721AM_Fuzz_Test } from "./_FloorERC721AM.fuzz.t.sol";
-
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { FloorERC721AM } from "../../../utils/mocks/asset-modules/FloorERC721AM.sol";
+import { FloorERC721AM_Fuzz_Test } from "./_FloorERC721AM.fuzz.t.sol";
 import { PrimaryAM } from "../../../../src/asset-modules/abstracts/AbstractPrimaryAM.sol";
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 

--- a/test/fuzz/asset-modules/FloorERC721AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/GetValue.fuzz.t.sol
@@ -4,9 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { FloorERC721AM_Fuzz_Test } from "./_FloorERC721AM.fuzz.t.sol";
-
 import { Constants } from "../../../utils/Constants.sol";
+import { FloorERC721AM_Fuzz_Test } from "./_FloorERC721AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getValue" of contract "FloorERC721AM".

--- a/test/fuzz/asset-modules/FloorERC721AM/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/ProcessDirectDeposit.fuzz.t.sol
@@ -51,7 +51,7 @@ contract ProcessDirectDeposit_FloorERC721AM_Fuzz_Test is FloorERC721AM_Fuzz_Test
     }
 
     function testFuzz_Revert_processDirectDeposit_WrongID(uint256 assetId) public {
-        vm.assume(assetId > 1); //Not in range
+        assetId = bound(assetId, 1 + 1, type(uint256).max);
         vm.prank(users.owner);
         floorERC721AM.addAsset(address(mockERC721.nft2), 0, 1, oraclesNft2ToUsd);
         vm.prank(users.riskManager);

--- a/test/fuzz/asset-modules/FloorERC721AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -41,7 +41,7 @@ contract ProcessIndirectDeposit_FloorERC721AM_Fuzz_Test is FloorERC721AM_Fuzz_Te
     }
 
     function testFuzz_Revert_processIndirectDeposit_WrongID(uint256 assetId) public {
-        vm.assume(assetId > 1); //Not in range
+        assetId = bound(assetId, 1 + 1, type(uint256).max);
         vm.prank(users.owner);
         floorERC721AM.addAsset(address(mockERC721.nft2), 0, 1, oraclesNft2ToUsd);
         vm.prank(users.riskManager);
@@ -77,10 +77,12 @@ contract ProcessIndirectDeposit_FloorERC721AM_Fuzz_Test is FloorERC721AM_Fuzz_Te
         int256 deltaExposureUpperAssetToAsset,
         uint112 maxExposure
     ) public {
-        vm.assume(deltaExposureUpperAssetToAsset > 0);
-        vm.assume(uint256(deltaExposureUpperAssetToAsset) < maxExposure);
+        deltaExposureUpperAssetToAsset = bound(
+            deltaExposureUpperAssetToAsset, 1, int256(uint256(type(uint112).max)) - 1
+        );
+        maxExposure = uint112(bound(maxExposure, uint256(deltaExposureUpperAssetToAsset) + 1, type(uint112).max));
         // To avoid overflow when calculating "usdExposureUpperAssetToAsset"
-        vm.assume(exposureUpperAssetToAsset < type(uint112).max);
+        exposureUpperAssetToAsset = bound(exposureUpperAssetToAsset, 0, type(uint112).max - 1);
 
         vm.prank(users.owner);
         floorERC721AM.addAsset(address(mockERC721.nft2), 0, type(uint256).max, oraclesNft2ToUsd);
@@ -89,7 +91,11 @@ contract ProcessIndirectDeposit_FloorERC721AM_Fuzz_Test is FloorERC721AM_Fuzz_Te
 
         (uint256 actualValueInUsd,,) = floorERC721AM.getValue(address(creditorUsd), address(mockERC721.nft2), 0, 1);
 
-        vm.assume(actualValueInUsd * exposureUpperAssetToAsset < type(uint256).max);
+        exposureUpperAssetToAsset = bound(
+            exposureUpperAssetToAsset,
+            0,
+            actualValueInUsd == 0 ? type(uint256).max : type(uint256).max / actualValueInUsd
+        );
 
         vm.prank(address(registry));
         (uint256 recursiveCalls, uint256 usdExposureUpperAssetToAsset) = floorERC721AM.processIndirectDeposit(

--- a/test/fuzz/asset-modules/FloorERC721AM/_FloorERC721AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/FloorERC721AM/_FloorERC721AM.fuzz.t.sol
@@ -4,9 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { Fuzz_Test } from "../../Fuzz.t.sol";
-
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
+import { Fuzz_Test } from "../../Fuzz.t.sol";
 
 /**
  * @notice Common logic needed by all "FloorERC721AM" fuzz tests.

--- a/test/fuzz/asset-modules/SlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -36,7 +36,7 @@ contract CalculateValueAndRiskFactors_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuz
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         assetRates[0] = bound(assetRates[0], 0, type(uint64).max);
@@ -53,7 +53,7 @@ contract CalculateValueAndRiskFactors_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuz
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         slipstreamAM.setRiskParameters(creditor, 0, riskFactor);
 

--- a/test/fuzz/asset-modules/SlipstreamAM/GetPrincipalAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetPrincipalAmounts.fuzz.t.sol
@@ -34,16 +34,8 @@ contract GetPrincipalAmounts_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         uint256 priceToken1
     ) public view {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        // Avoid divide by 0, which is already checked in earlier in function.
-        vm.assume(priceToken1 > 0);
-        // Function will overFlow, not realistic.
-        vm.assume(priceToken0 <= type(uint256).max / 1e28);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
 
         uint160 sqrtPriceX96 = slipstreamAM.getSqrtPriceX96(priceToken0, priceToken1);
         (uint256 expectedAmount0, uint256 expectedAmount1) = LiquidityAmounts.getAmountsForLiquidity(

--- a/test/fuzz/asset-modules/SlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
@@ -37,13 +37,10 @@ contract GetSqrtPriceX96_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
     }
 
     function testFuzz_Success_getSqrtPriceX96_Overflow(uint256 priceToken0, uint256 priceToken1) public view {
-        // Avoid divide by 0 which, is already checked in earlier in function.
-        priceToken1 = bound(priceToken1, 1, type(uint256).max);
-        // Function will overFlow, not realistic.
-        priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
-
         // Cast to uint160 overflows (test-case).
-        vm.assume(priceToken0 / priceToken1 >= 2 ** 128);
+        priceToken0 = bound(priceToken0, 2 ** 128, type(uint256).max / 1e28);
+        // Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1 = bound(priceToken1, 1, priceToken0 / 2 ** 128);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);
@@ -60,7 +57,7 @@ contract GetSqrtPriceX96_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/SlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
@@ -57,7 +57,7 @@ contract GetSqrtPriceX96_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128 - 1);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/SlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -148,12 +148,9 @@ contract GetUnderlyingAssetsAmounts_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_
         // And: position is valid.
         position = givenValidPosition(position);
 
-        // And: there is no fee.
-        // ToDo: include fees.
+        // And: fees are the already realised fees (tokensOwed), the pool has no fee growth.
         position.feeGrowthInside0LastX128 = 0;
         position.feeGrowthInside1LastX128 = 0;
-        position.tokensOwed0 = 0;
-        position.tokensOwed1 = 0;
 
         // And: State is persisted.
         addAssetToArcadia(address(token0), int256(asset0.usdValue));
@@ -185,8 +182,16 @@ contract GetUnderlyingAssetsAmounts_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_
             TickMath.getSqrtRatioAtTick(position.tickUpper),
             position.liquidity
         );
-        assertEq(underlyingAssetsAmounts[0], expectedUnderlyingAssetsAmount0);
-        assertEq(underlyingAssetsAmounts[1], expectedUnderlyingAssetsAmount1);
+
+        // And: fees are added to the principal, capped at the principal.
+        uint256 expectedFee0 = position.tokensOwed0 > expectedUnderlyingAssetsAmount0
+            ? expectedUnderlyingAssetsAmount0
+            : position.tokensOwed0;
+        uint256 expectedFee1 = position.tokensOwed1 > expectedUnderlyingAssetsAmount1
+            ? expectedUnderlyingAssetsAmount1
+            : position.tokensOwed1;
+        assertEq(underlyingAssetsAmounts[0], expectedUnderlyingAssetsAmount0 + expectedFee0);
+        assertEq(underlyingAssetsAmounts[1], expectedUnderlyingAssetsAmount1 + expectedFee1);
     }
 
     function testFuzz_Success_GetUnderlyingAssetsAmounts_AmountIsZero(uint96 tokenId) public view {

--- a/test/fuzz/asset-modules/SlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -15,7 +15,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "SlipstreamAM".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(unsafe-typecast,divide-before-multiply)
 contract GetUnderlyingAssetsAmounts_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -142,7 +142,12 @@ contract GetUnderlyingAssetsAmounts_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_
 
         // And: Cast to uint160 in _getSqrtPriceX96 does not overflow.
         if (asset1.usdValue > 0) {
-            vm.assume(asset0.usdValue / asset1.usdValue / 10 ** asset0.decimals < 2 ** 128 / 10 ** asset1.decimals);
+            uint256 maxUsdValue0 = type(uint256).max / 10 ** (46 - asset0.decimals);
+            uint256 maxRatio = 2 ** 128 / 10 ** asset1.decimals;
+            if (maxRatio < maxUsdValue0 / asset1.usdValue / 10 ** asset0.decimals) {
+                maxUsdValue0 = asset1.usdValue * maxRatio * 10 ** asset0.decimals - 1;
+            }
+            asset0.usdValue = bound(asset0.usdValue, 0, maxUsdValue0);
         }
 
         // And: position is valid.

--- a/test/fuzz/asset-modules/SlipstreamAM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetValue.fuzz.t.sol
@@ -33,8 +33,6 @@ contract GetValue_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
 
-    // ToDo: getValue with fuzzed tokensOwed and pending Fees.
-
     function testFuzz_Success_getValue_valueInUsd(TestVariables memory vars) public {
         // Check that ticks are within allowed ranges.
         vm.assume(vars.tickLower < vars.tickUpper);

--- a/test/fuzz/asset-modules/SlipstreamAM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/GetValue.fuzz.t.sol
@@ -35,9 +35,7 @@ contract GetValue_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
 
     function testFuzz_Success_getValue_valueInUsd(TestVariables memory vars) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(vars.tickLower < vars.tickUpper);
-        vm.assume(isWithinAllowedRange(vars.tickLower));
-        vm.assume(isWithinAllowedRange(vars.tickUpper));
+        (vars.tickLower, vars.tickUpper) = givenValidTicks(vars.tickLower, vars.tickUpper);
 
         // Deploy and sort tokens.
         vars.decimals0 = bound(vars.decimals0, 6, 18);
@@ -53,22 +51,20 @@ contract GetValue_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         }
 
         // Avoid divide by 0 in next line.
-        vm.assume(vars.priceToken1 > 0);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(vars.priceToken0 / vars.priceToken1 < 2 ** 128);
+        vars.priceToken1 = uint64(bound(vars.priceToken1, 1, type(uint64).max));
         // Check that sqrtPriceX96 is within allowed Slipstream ranges.
+        uint256 minPriceToken0 = (vars.priceToken1 * 10 ** (18 - vars.decimals1) - 1) / 10 ** 28 + 1;
+        vars.priceToken0 =
+            uint64(bound(vars.priceToken0, (minPriceToken0 - 1) / 10 ** (18 - vars.decimals0) + 1, type(uint64).max));
         uint160 sqrtPriceX96 = slipstreamAM.getSqrtPriceX96(
             vars.priceToken0 * 10 ** (18 - vars.decimals0), vars.priceToken1 * 10 ** (18 - vars.decimals1)
         );
-
-        vm.assume(sqrtPriceX96 >= 4_295_128_739);
-        vm.assume(sqrtPriceX96 <= 1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342);
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         ICLPoolExtension pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(vars.liquidity <= pool.maxLiquidityPerTick());
+        vars.liquidity = uint80(bound(vars.liquidity, 0, pool.maxLiquidityPerTick()));
         // Mint liquidity position.
         (uint256 tokenId,,) =
             addLiquidityCL(pool, vars.liquidity, users.liquidityProvider, vars.tickLower, vars.tickUpper, false);

--- a/test/fuzz/asset-modules/SlipstreamAM/IsAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/IsAllowed.fuzz.t.sol
@@ -15,6 +15,7 @@ import {
 /**
  * @notice Fuzz tests for the function "isAllowed" of contract "SlipstreamAM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IsAllowed_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -82,8 +83,8 @@ contract IsAllowed_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         public
     {
         vm.assume(lp != address(0));
-        vm.assume(maxExposureA > 0);
-        vm.assume(maxExposureB > 0);
+        maxExposureA = uint128(bound(maxExposureA, 1, type(uint128).max));
+        maxExposureB = uint128(bound(maxExposureB, 1, type(uint128).max));
 
         // Create a LP-position of two underlying assets: token1 and token2.
         ERC20 tokenA = ERC20(address(mockERC20.token1));
@@ -132,8 +133,8 @@ contract IsAllowed_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
 
     function testFuzz_Success_isAllowed_Positive(address lp, uint128 maxExposureA, uint128 maxExposureB) public {
         vm.assume(lp != address(0));
-        vm.assume(maxExposureA > 0);
-        vm.assume(maxExposureB > 0);
+        maxExposureA = uint128(bound(maxExposureA, 1, type(uint128).max));
+        maxExposureB = uint128(bound(maxExposureB, 1, type(uint128).max));
 
         // Create a LP-position of two underlying assets: token1 and token2.
         ERC20 tokenA = ERC20(address(mockERC20.token1));

--- a/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectDeposit.fuzz.t.sol
@@ -56,21 +56,17 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
     ) public {
         vm.assume(unprivilegedAddress != address(registry));
 
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -92,24 +88,19 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
         uint256 exposureUpperAssetToAsset,
         int256 amount
     ) public {
-        vm.assume(amount != 0);
-        vm.assume(amount != 1);
+        vm.assume(amount != 0 && amount != 1);
 
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -133,21 +124,17 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -168,12 +155,10 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -235,21 +220,17 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -270,12 +251,10 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -336,13 +315,11 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
@@ -375,12 +352,10 @@ contract ProcessIndirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test
                 );
 
                 // Check that exposure to underlying tokens stays below maxExposures.
-                vm.assume(amount0 + initialExposure0 < maxExposure0);
-                vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-                // And: Usd exposure of underlying assets does not overflow.
-                vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-                vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+                (initialExposure0, maxExposure0) =
+                    givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+                (initialExposure1, maxExposure1) =
+                    givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
             }
 
             // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -55,21 +55,17 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -91,12 +87,10 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -153,21 +147,17 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -188,12 +178,10 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -248,21 +236,17 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -283,12 +267,10 @@ contract ProcessIndirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_T
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
@@ -16,6 +16,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Common logic needed by all "SlipstreamAM" fuzz tests.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 abstract contract SlipstreamAM_Fuzz_Test is Fuzz_Test, SlipstreamFixture {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -103,20 +104,9 @@ abstract contract SlipstreamAM_Fuzz_Test is Fuzz_Test, SlipstreamFixture {
         pure
         returns (uint256 sqrtPriceX96)
     {
-        // Avoid divide by 0, which is already checked in earlier in function.
-        vm.assume(priceToken1 > 0);
-        // Function will overFlow, not realistic.
-        vm.assume(priceToken0 <= type(uint256).max / 10 ** 28);
-        vm.assume(priceToken1 <= type(uint256).max / 10 ** 18);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
-
-        // sqrtPriceX96 must be within ranges, or TickMath reverts.
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);
         sqrtPriceX96 = sqrtPriceXd14 * 2 ** 96 / 1e14;
-        vm.assume(sqrtPriceX96 >= 4_295_128_739);
-        vm.assume(sqrtPriceX96 <= 1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342);
     }
 
     function givenValidPosition(NonfungiblePositionManagerMock.Position memory position)
@@ -125,14 +115,22 @@ abstract contract SlipstreamAM_Fuzz_Test is Fuzz_Test, SlipstreamFixture {
         returns (NonfungiblePositionManagerMock.Position memory)
     {
         // Given: poolId is non zero (=position is initialised).
-        // forge-lint: disable-next-item(unsafe-typecast)
         position.poolId = uint80(bound(position.poolId, 1, type(uint80).max));
 
         // And: Ticks are within allowed ranges.
-        vm.assume(isWithinAllowedRange(position.tickLower));
-        vm.assume(isWithinAllowedRange(position.tickUpper));
+        position.tickLower = int24(bound(position.tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK));
+        position.tickUpper = int24(bound(position.tickUpper, TickMath.MIN_TICK, TickMath.MAX_TICK));
 
         return position;
+    }
+
+    function givenValidTicks(int24 tickLower, int24 tickUpper)
+        public
+        pure
+        returns (int24 tickLower_, int24 tickUpper_)
+    {
+        tickLower_ = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
+        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, TickMath.MAX_TICK));
     }
 
     function isWithinAllowedRange(int24 tick) internal pure returns (bool) {

--- a/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
@@ -24,8 +24,7 @@ abstract contract SlipstreamAM_Fuzz_Test is Fuzz_Test, SlipstreamFixture {
     /////////////////////////////////////////////////////////////// */
 
     uint256 internal constant INT256_MAX = 2 ** 255 - 1;
-    // While the true minimum value of an int256 is 2 ** 255, Solidity overflows on a negation (since INT256_MAX is one less).
-    // -> This true minimum value will overflow and revert.
+    // Negating the true minimum of 2 ** 255 overflows, so this stops one below it.
     uint256 internal constant INT256_MIN = 2 ** 255 - 1;
 
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/_SlipstreamAM.fuzz.t.sol
@@ -122,18 +122,4 @@ abstract contract SlipstreamAM_Fuzz_Test is Fuzz_Test, SlipstreamFixture {
 
         return position;
     }
-
-    function givenValidTicks(int24 tickLower, int24 tickUpper)
-        public
-        pure
-        returns (int24 tickLower_, int24 tickUpper_)
-    {
-        tickLower_ = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
-        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, TickMath.MAX_TICK));
-    }
-
-    function isWithinAllowedRange(int24 tick) internal pure returns (bool) {
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return (tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick))) <= uint256(uint24(TickMath.MAX_TICK));
-    }
 }

--- a/test/fuzz/asset-modules/SlipstreamAM/processDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/processDirectDeposit.fuzz.t.sol
@@ -59,21 +59,17 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         vm.assume(unprivilegedAddress != address(registry));
 
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -118,21 +114,17 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         uint112 maxExposure0
     ) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -147,7 +139,8 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
 
         // Condition on which the call should revert: exposure to token0 becomes bigger than maxExposure0.
         vm.assume(amount0 > 0);
-        vm.assume(amount0 + initialExposure0 >= maxExposure0);
+        initialExposure0 =
+            uint112(bound(initialExposure0, maxExposure0 > amount0 ? maxExposure0 - amount0 : 0, type(uint112).max));
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(priceToken0), initialExposure0, maxExposure0);
@@ -169,21 +162,17 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         uint112 maxExposure1
     ) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -201,7 +190,8 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
 
         // Condition on which the call should revert: exposure to token1 becomes bigger than maxExposure1.
         vm.assume(amount1 > 0);
-        vm.assume(amount1 + initialExposure1 >= maxExposure1);
+        initialExposure1 =
+            uint112(bound(initialExposure1, maxExposure1 > amount1 ? maxExposure1 - amount1 : 0, type(uint112).max));
 
         // And: Usd value of underlying asset does not overflow.
         vm.assume(amount0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
@@ -229,20 +219,18 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         uint112 maxExposure1
     ) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
         liquidity = uint128(bound(liquidity, 1, type(uint128).max));
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -263,14 +251,10 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            // vm.assume(amount0 + initialExposure0 < maxExposure0);
-            // vm.assume(amount1 + initialExposure1 < maxExposure1);
-            initialExposure0 = uint112(bound(initialExposure0, 0, maxExposure0 + amount0));
-            initialExposure1 = uint112(bound(initialExposure1, 0, maxExposure1 + amount1));
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 < type(uint112).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 < type(uint112).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint112).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint112).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -281,8 +265,13 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
             // And: usd exposure to protocol below max usd exposure.
             (uint256 usdExposureProtocol,,) =
                 slipstreamAM.getValue(address(creditorUsd), address(slipstreamPositionManager), tokenId, 1);
-            vm.assume(usdExposureProtocol < type(uint112).max);
-            maxUsdExposureProtocol = uint112(bound(maxUsdExposureProtocol, 0, usdExposureProtocol));
+            maxUsdExposureProtocol = uint112(
+                bound(
+                    maxUsdExposureProtocol,
+                    0,
+                    usdExposureProtocol < type(uint112).max ? usdExposureProtocol : type(uint112).max
+                )
+            );
         }
 
         vm.prank(users.riskManager);
@@ -306,21 +295,17 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -341,12 +326,10 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -410,21 +393,17 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -445,12 +424,10 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -510,13 +487,11 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
@@ -549,12 +524,10 @@ contract ProcessDirectDeposit_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Test {
                 );
 
                 // Check that exposure to underlying tokens stays below maxExposures.
-                vm.assume(amount0 + initialExposure0 < maxExposure0);
-                vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-                // And: Usd value of underlying assets does not overflow.
-                vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-                vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+                (initialExposure0, maxExposure0) =
+                    givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+                (initialExposure1, maxExposure1) =
+                    givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
             }
 
             // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/SlipstreamAM/processDirectWithdrawal.t.sol
+++ b/test/fuzz/asset-modules/SlipstreamAM/processDirectWithdrawal.t.sol
@@ -56,21 +56,17 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -92,12 +88,10 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -155,21 +149,17 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -190,12 +180,10 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -250,21 +238,17 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Slipstream pool initiated at tickCurrent with cardinality 300.
         pool = createPoolCL(address(token0), address(token1), 1, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityCL(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -285,12 +269,10 @@ contract ProcessDirectWithdrawal_SlipstreamAM_Fuzz_Test is SlipstreamAM_Fuzz_Tes
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/StakedAerodromeAM/ClaimReward_Position.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/ClaimReward_Position.fuzz.t.sol
@@ -67,7 +67,7 @@ contract ClaimReward_Position_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_F
         stakedAerodromeAM.addAsset(address(aeroGauge));
 
         // Given: Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
         // And: State is persisted.
         setStakedAerodromeAMState(assetState, positionState, address(aeroPool), positionId);
@@ -140,7 +140,7 @@ contract ClaimReward_Position_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_F
         stakedAerodromeAM.addAsset(address(aeroGauge));
 
         // Given: Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
         // And reward is zero.
         positionState.lastRewardPosition = 0;

--- a/test/fuzz/asset-modules/StakedAerodromeAM/ClaimReward_Position.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/ClaimReward_Position.fuzz.t.sol
@@ -75,7 +75,7 @@ contract ClaimReward_Position_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_F
         // And : stakedAerodromeAM should have sufficient amount of reward tokens
         uint256 currentRewardPosition = stakedAerodromeAM.rewardOf(positionId);
 
-        // And reward is non-zero.
+        // And: reward is non-zero.
         vm.assume(currentRewardPosition > 0);
 
         deal(AERO, address(stakedAerodromeAM), currentRewardPosition);
@@ -142,7 +142,7 @@ contract ClaimReward_Position_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_F
         // Given: Valid state
         (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max);
 
-        // And reward is zero.
+        // And: reward is zero.
         positionState.lastRewardPosition = 0;
         positionState.lastRewardPerTokenPosition = assetState.lastRewardPerTokenGlobal;
         assetState.currentRewardGlobal = 0;

--- a/test/fuzz/asset-modules/StakedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
@@ -39,7 +39,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
 
     function testFuzz_Revert_decreaseLiquidity_NotOwner(uint256 id, uint128 amount, address owner) public {
         // Given : Amount is greater than 0.
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
 
         // Given : Owner is not the caller.
         vm.assume(owner != users.accountOwner);
@@ -80,12 +80,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         stakedAerodromeAM.addAsset(address(aeroGauge));
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-        // And : Account has a non-zero balance.
-        vm.assume(positionState.amountStaked > 0);
-        // And : Account has a balance smaller as type(uint128).max.
-        vm.assume(positionState.amountStaked < type(uint128).max);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
         // And: State is persisted.
         setStakedAerodromeAMState(assetState, positionState, address(aeroPool), positionId);
@@ -128,10 +123,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         stakedAerodromeAM.addAsset(address(aeroGauge));
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-        // And : Account has a non-zero balance
-        vm.assume(positionState.amountStaked > 0);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
         // And: State is persisted.
         setStakedAerodromeAMState(assetState, positionState, address(aeroPool), positionId);
@@ -230,10 +222,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         uint256 currentRewardAccount;
         {
             // Given : Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-            // And : Account has a balance bigger as 1.
-            vm.assume(positionState.amountStaked > 1);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 2, type(uint128).max);
 
             // And: State is persisted.
             setStakedAerodromeAMState(assetState, positionState, address(aeroPool), positionId);
@@ -331,10 +320,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         stakedAerodromeAM.addAsset(address(aeroGauge));
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-        // And : Account has a non-zero balance
-        vm.assume(positionState.amountStaked > 0);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
         // And reward is zero.
         positionState.lastRewardPosition = 0;
@@ -418,10 +404,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
 
         {
             // Given : Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
-
-            // And : Account has a balance bigger as 1.
-            vm.assume(positionState.amountStaked > 1);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 2, type(uint128).max);
 
             // And reward is zero.
             positionState.lastRewardPosition = 0;

--- a/test/fuzz/asset-modules/StakedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
@@ -143,7 +143,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         // And : Enough AERO is claimable in stakedAerodromeAM
         deal(AERO, address(stakedAerodromeAM), currentRewardAccount);
 
-        // And reward is non-zero.
+        // And: reward is non-zero.
         vm.assume(currentRewardAccount > 0);
 
         // When : Account withdraws full position from stakingAM
@@ -237,7 +237,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
             aeroGauge.deposit(positionState.amountStaked);
             vm.stopPrank();
 
-            // And reward is non-zero.
+            // And: reward is non-zero.
             currentRewardAccount = stakedAerodromeAM.rewardOf(positionId);
             vm.assume(currentRewardAccount > 0);
 
@@ -322,7 +322,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         // Given : Valid state
         (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
 
-        // And reward is zero.
+        // And: reward is zero.
         positionState.lastRewardPosition = 0;
         positionState.lastRewardPerTokenPosition = assetState.lastRewardPerTokenGlobal;
         assetState.currentRewardGlobal = 0;
@@ -406,7 +406,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
             // Given : Valid state
             (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 2, type(uint128).max);
 
-            // And reward is zero.
+            // And: reward is zero.
             positionState.lastRewardPosition = 0;
             positionState.lastRewardPerTokenPosition = assetState.lastRewardPerTokenGlobal;
             assetState.currentRewardGlobal = 0;
@@ -517,7 +517,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         // And : Assume previously earned rewards were previously claimed by the stakedAerodromeAM
         deal(AERO, address(stakedAerodromeAM), positionState.lastRewardPosition);
 
-        // And reward is non-zero.
+        // And: reward is non-zero.
         vm.assume(currentRewardAccount > 0);
 
         // When : Account withdraws full position from stakingAM

--- a/test/fuzz/asset-modules/StakedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
@@ -80,7 +80,7 @@ contract DecreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         stakedAerodromeAM.addAsset(address(aeroGauge));
 
         // Given : Valid state
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 1, type(uint128).max - 1);
 
         // And: State is persisted.
         setStakedAerodromeAMState(assetState, positionState, address(aeroPool), positionId);

--- a/test/fuzz/asset-modules/StakedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
@@ -40,9 +40,9 @@ contract IncreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
         vm.assume(account_ != randomAddress);
         vm.assume(account_ != address(0));
         // Given : Amount is greater than zero
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
         // Given : positionId is greater than 0
-        vm.assume(positionId > 0);
+        positionId = uint96(bound(positionId, 1, type(uint96).max));
         // Given : Owner of positionId is not the Account
         stakedAerodromeAM.setOwnerOfPositionId(randomAddress, positionId);
 
@@ -98,7 +98,7 @@ contract IncreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
             stakedAerodromeAM.addAsset(address(aeroGauge));
 
             // Given : Valid state
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max - 1);
 
             // And: State is persisted.
             setStakedAerodromeAMState(assetState, positionState, address(aeroPool), positionId);
@@ -108,7 +108,6 @@ contract IncreaseLiquidity_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz
 
             // And: updated totalStake should not be greater than uint128.
             // And: Amount staked is greater than zero.
-            vm.assume(assetState.totalStaked < type(uint128).max);
             amount = uint128(bound(amount, 1, type(uint128).max - assetState.totalStaked));
 
             deal(address(aeroPool), account_, amount);

--- a/test/fuzz/asset-modules/StakedAerodromeAM/Mint.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedAerodromeAM/Mint.fuzz.t.sol
@@ -34,7 +34,7 @@ contract Mint_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz_Test {
 
     function testFuzz_Revert_mint_AssetNotAllowed(uint8 assetDecimals, uint128 amount, address account_) public {
         // Given : Amount is greater than zero
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
 
         assetDecimals = uint8(bound(assetDecimals, 0, 18));
         address asset = address(new ERC20Mock("Asset", "AST", assetDecimals));
@@ -75,14 +75,13 @@ contract Mint_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz_Test {
         {
             // And: Valid state.
             StakingAM.PositionState memory positionState;
-            (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+            (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max - 1);
 
             // And: State is persisted.
             setStakedAerodromeAMState(assetState, positionState, address(aeroPool), 0);
 
             // And: updated totalStake should not be greater than uint128.
             // And: Amount staked is greater than zero.
-            vm.assume(assetState.totalStaked < type(uint128).max);
             amount = uint128(bound(amount, 1, type(uint128).max - assetState.totalStaked));
 
             deal(address(aeroPool), account_, amount);
@@ -153,7 +152,7 @@ contract Mint_StakedAerodromeAM_Fuzz_Test is StakedAerodromeAM_Fuzz_Test {
 
         // And: Valid state.
         StakingAM.PositionState memory positionState;
-        (assetState, positionState) = givenValidStakingAMState(assetState, positionState);
+        (assetState, positionState) = givenValidStakingAMState(assetState, positionState, 0, type(uint128).max - 1);
 
         // And: TotalStaked is 0.
         assetState.totalStaked = 0;

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -36,7 +36,7 @@ contract CalculateValueAndRiskFactors_StakedSlipstreamAM_Fuzz_Test is StakedSlip
         address creditor,
         uint256[3] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         underlyingAssetsAmounts[2] = bound(underlyingAssetsAmounts[2], 0, type(uint64).max);
@@ -59,7 +59,7 @@ contract CalculateValueAndRiskFactors_StakedSlipstreamAM_Fuzz_Test is StakedSlip
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
         liquidationFactors[2] = uint16(bound(liquidationFactors[2], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         stakedSlipstreamAM.setRiskParameters(creditor, 0, riskFactor);
 
@@ -100,7 +100,7 @@ contract CalculateValueAndRiskFactors_StakedSlipstreamAM_Fuzz_Test is StakedSlip
         address creditor,
         uint256[3] memory underlyingAssetsAmounts
     ) public {
-        // And riskFactor is set.
+        // And: riskFactor is set.
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
         vm.prank(address(registry));
         stakedSlipstreamAM.setRiskParameters(creditor, 0, riskFactor);

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/GetPrincipalAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/GetPrincipalAmounts.fuzz.t.sol
@@ -40,7 +40,7 @@ contract GetPrincipalAmounts_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128 - 1);
 
         uint160 sqrtPriceX96 = stakedSlipstreamAM.getSqrtPriceX96(priceToken0, priceToken1);
         (uint256 expectedAmount0, uint256 expectedAmount1) = LiquidityAmounts.getAmountsForLiquidity(

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
@@ -37,13 +37,10 @@ contract GetSqrtPriceX96_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz
     }
 
     function testFuzz_Success_getSqrtPriceX96_Overflow(uint256 priceToken0, uint256 priceToken1) public view {
-        // Avoid divide by 0 which, is already checked in earlier in function.
-        priceToken1 = bound(priceToken1, 1, type(uint256).max);
-        // Function will overFlow, not realistic.
-        priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
-
         // Cast to uint160 overflows (test-case).
-        vm.assume(priceToken0 / priceToken1 >= 2 ** 128);
+        priceToken0 = bound(priceToken0, 2 ** 128, type(uint256).max / 1e28);
+        // Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1 = bound(priceToken1, 1, priceToken0 / 2 ** 128);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/GetSqrtPriceX96.fuzz.t.sol
@@ -57,7 +57,7 @@ contract GetSqrtPriceX96_StakedSlipstreamAM_Fuzz_Test is StakedSlipstreamAM_Fuzz
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128 - 1);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -42,6 +42,7 @@ contract GetUnderlyingAssetsAmounts_StakedSlipstreamAM_Fuzz_Test is StakedSlipst
         uint256 rewardGrowthGlobalX128Last,
         uint256 rewardGrowthGlobalX128Current
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given: Ticks are within allowed ranges.
         position = givenValidPosition(position, 1);
 
@@ -127,6 +128,7 @@ contract GetUnderlyingAssetsAmounts_StakedSlipstreamAM_Fuzz_Test is StakedSlipst
         uint256 rewardGrowthGlobalX128Last,
         uint256 rewardGrowthGlobalX128Current
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given: Ticks are within allowed ranges.
         position = givenValidPosition(position, 1);
 

--- a/test/fuzz/asset-modules/StakedSlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedSlipstreamAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -56,7 +56,7 @@ contract GetUnderlyingAssetsAmounts_StakedSlipstreamAM_Fuzz_Test is StakedSlipst
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128 - 1);
 
         // And : gauge is deployed and added to registry.
         {
@@ -142,7 +142,7 @@ contract GetUnderlyingAssetsAmounts_StakedSlipstreamAM_Fuzz_Test is StakedSlipst
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128 - 1);
 
         // And : gauge is deployed and added to registry.
         {

--- a/test/fuzz/asset-modules/StakedStargateAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/AddAsset.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { StakedStargateAM_Fuzz_Test } from "./_StakedStargateAM.fuzz.t.sol";
 import { StakedStargateAM } from "../../../../src/asset-modules/Stargate-Finance/StakedStargateAM.sol";
+import { StakedStargateAM_Fuzz_Test } from "./_StakedStargateAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "StakedStargateAM".

--- a/test/fuzz/asset-modules/StakedStargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -34,7 +34,7 @@ contract CalculateValueAndRiskFactors_StakedStargateAM_Fuzz_Test is StakedStarga
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         assetRates[0] = bound(assetRates[0], 0, type(uint64).max);
@@ -52,7 +52,7 @@ contract CalculateValueAndRiskFactors_StakedStargateAM_Fuzz_Test is StakedStarga
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         stakedStargateAM.setRiskParameters(creditor, 0, riskFactor);
 
@@ -84,7 +84,7 @@ contract CalculateValueAndRiskFactors_StakedStargateAM_Fuzz_Test is StakedStarga
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // And riskFactor is set.
+        // And: riskFactor is set.
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
         vm.prank(address(registry));
         stakedStargateAM.setRiskParameters(creditor, 0, riskFactor);

--- a/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
@@ -81,8 +81,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         // And reward is available.
         lpStakingTimeMock.setInfoForPoolId(pid, underlyingAssetsAmounts[1], address(poolMock));
 
-        // And: The reward token is priced by the same oracle rate as token1, the pool token converts
-        // LP to the underlying with the pool its own liquidity to supply ratio.
+        // And: The expected value uses the pool its liquidity to supply ratio.
         uint256 value0;
         uint256 value1;
         {

--- a/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { StakedStargateAM_Fuzz_Test } from "./_StakedStargateAM.fuzz.t.sol";
 
 import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.sol";
+import { Constants } from "../../../utils/Constants.sol";
 
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "StakedStargateAM".
@@ -26,7 +27,6 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
     /////////////////////////////////////////////////////////////// */
 
     function testFuzz_Success_getRiskFactors_NonZeroValueInUsd(
-        uint256[2] memory assetRates,
         uint16[2] memory collateralFactors,
         uint16[2] memory liquidationFactors,
         uint16 riskFactor,
@@ -35,18 +35,9 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         uint256 poolId,
         uint256 pid
     ) public {
-        // ToDo assetRates are hard coded for now.
-        assetRates[0] = 3_000_000_000_000_000_000_000;
-        assetRates[1] = 6_000_000_000_000_000_000_000;
-
         // Given amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 10_000, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 10_000, type(uint64).max);
-
-        uint256 value0 = underlyingAssetsAmounts[0] * assetRates[0] / 1e18;
-        uint256 value1 = underlyingAssetsAmounts[1] * assetRates[1] / 1e18;
-        uint256 expectedValueInUsd = value0 + value1;
-        vm.assume(expectedValueInUsd > 0);
 
         // And: Risk factors are below max risk factor.
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
@@ -89,6 +80,19 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
 
         // And reward is available.
         lpStakingTimeMock.setInfoForPoolId(pid, underlyingAssetsAmounts[1], address(poolMock));
+
+        // And: The reward token is priced by the same oracle rate as token1, the pool token converts
+        // LP to the underlying with the pool its own liquidity to supply ratio.
+        uint256 value0;
+        uint256 value1;
+        {
+            uint256 rateToken1 = rates.token1ToUsd * 10 ** (18 - Constants.TOKEN_ORACLE_DECIMALS);
+            uint256 ratePool = rateToken1 * poolMock.totalLiquidity() / poolMock.totalSupply();
+            value0 = underlyingAssetsAmounts[0] * ratePool / 1e18;
+            value1 = underlyingAssetsAmounts[1] * rateToken1 / 1e18;
+        }
+        uint256 expectedValueInUsd = value0 + value1;
+        vm.assume(expectedValueInUsd > 0);
 
         uint256 expectedCollateralFactor = riskFactor
             * ((value0 * collateralFactors[0] + value1 * collateralFactors[1]) / expectedValueInUsd)

--- a/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/GetRiskFactors.fuzz.t.sol
@@ -35,7 +35,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         uint256 poolId,
         uint256 pid
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 10_000, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 10_000, type(uint64).max);
 
@@ -46,11 +46,11 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         stakedStargateAM.setRiskParameters(creditor, 0, riskFactor);
 
-        // And state stargateAssetModule is set.
+        // And: state stargateAssetModule is set.
         sgFactoryMock.setPool(poolId, address(poolMock));
         poolMock.setToken(address(mockERC20.token1));
         stargateAssetModule.addAsset(poolId);
@@ -61,7 +61,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         );
         vm.stopPrank();
 
-        // And staked pool is set.
+        // And: staked pool is set.
         lpStakingTimeMock.setInfoForPoolId(pid, 0, address(poolMock));
         stakedStargateAM.addAsset(pid);
         vm.startPrank(address(registry));
@@ -70,7 +70,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         );
         vm.stopPrank();
 
-        // And position is minted.
+        // And: position is minted.
         poolMock.setState(address(mockERC20.token1), underlyingAssetsAmounts[0], underlyingAssetsAmounts[0], 1);
         deal(address(poolMock), users.liquidityProvider, underlyingAssetsAmounts[0], true);
         vm.startPrank(users.liquidityProvider);
@@ -78,7 +78,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         uint256 positionId = stakedStargateAM.mint(address(poolMock), uint128(underlyingAssetsAmounts[0]));
         vm.stopPrank();
 
-        // And reward is available.
+        // And: reward is available.
         lpStakingTimeMock.setInfoForPoolId(pid, underlyingAssetsAmounts[1], address(poolMock));
 
         // And: The expected value uses the pool its liquidity to supply ratio.
@@ -121,7 +121,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         stargateOracle.transmit(int256(0));
         vm.stopPrank();
 
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 1, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
 
@@ -132,11 +132,11 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         stakedStargateAM.setRiskParameters(creditor, 0, riskFactor);
 
-        // And state stargateAssetModule is set.
+        // And: state stargateAssetModule is set.
         sgFactoryMock.setPool(poolId, address(poolMock));
         poolMock.setToken(address(mockERC20.token1));
         stargateAssetModule.addAsset(poolId);
@@ -147,7 +147,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         );
         vm.stopPrank();
 
-        // And staked pool is set.
+        // And: staked pool is set.
         lpStakingTimeMock.setInfoForPoolId(pid, 0, address(poolMock));
         stakedStargateAM.addAsset(pid);
         vm.startPrank(address(registry));
@@ -156,7 +156,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         );
         vm.stopPrank();
 
-        // And position is minted.
+        // And: position is minted.
         poolMock.setState(address(mockERC20.token1), underlyingAssetsAmounts[0], underlyingAssetsAmounts[0], 1);
         deal(address(poolMock), users.liquidityProvider, underlyingAssetsAmounts[0], true);
         vm.startPrank(users.liquidityProvider);
@@ -164,7 +164,7 @@ contract GetRiskFactors_StakedStargateAM_Fuzz_Test is StakedStargateAM_Fuzz_Test
         uint256 positionId = stakedStargateAM.mint(address(poolMock), uint128(underlyingAssetsAmounts[0]));
         vm.stopPrank();
 
-        // And reward is available.
+        // And: reward is available.
         lpStakingTimeMock.setInfoForPoolId(pid, underlyingAssetsAmounts[1], address(poolMock));
 
         (uint256 collateralFactor, uint256 liquidationFactor) =

--- a/test/fuzz/asset-modules/StakedStargateAM/StakeAndClaim.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/StakeAndClaim.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { StakedStargateAM_Fuzz_Test } from "./_StakedStargateAM.fuzz.t.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
+import { StakedStargateAM_Fuzz_Test } from "./_StakedStargateAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "_stakeAndClaim" of contract "StakedStargateAM".

--- a/test/fuzz/asset-modules/StakedStargateAM/WithdrawAndClaim.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StakedStargateAM/WithdrawAndClaim.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { StakedStargateAM_Fuzz_Test } from "./_StakedStargateAM.fuzz.t.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
+import { StakedStargateAM_Fuzz_Test } from "./_StakedStargateAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "_withdrawAndClaim" of contract "StakedStargateAM".

--- a/test/fuzz/asset-modules/StandardERC4626AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -4,11 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { StandardERC4626AM_Fuzz_Test } from "./_StandardERC4626AM.fuzz.t.sol";
-
-import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
-
 import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
+import { StandardERC4626AM_Fuzz_Test } from "./_StandardERC4626AM.fuzz.t.sol";
+import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts()" of contract "StandardERC4626AM".

--- a/test/fuzz/asset-modules/StandardERC4626AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/GetValue.fuzz.t.sol
@@ -33,20 +33,19 @@ contract GetValue_StandardERC4626AM_Fuzz_Test is StandardERC4626AM_Fuzz_Test {
         uint256 totalSupply,
         uint256 totalAssets
     ) public {
-        vm.assume(shares <= totalSupply);
-        vm.assume(totalSupply > 0);
-        vm.assume(totalAssets > 0);
-        vm.assume(rateToken1ToUsd_ > 0);
+        totalSupply = bound(totalSupply, 1, type(uint256).max);
+        totalAssets = bound(totalAssets, 1, type(uint256).max);
+        // A single holder can never hold more than totalSupply, and no Overflow ERC4626.
+        uint256 maxShares = type(uint256).max / totalAssets;
+        if (totalSupply < maxShares) maxShares = totalSupply;
+        shares = bound(shares, 1, maxShares);
 
-        // No Overflow Registry
-        vm.assume(rateToken1ToUsd_ <= type(uint256).max / Constants.WAD);
-        // No Overflow ERC4626
-        vm.assume(shares <= type(uint256).max / totalAssets);
-
-        vm.assume(
-            shares * totalAssets / totalSupply
-                > type(uint256).max / (Constants.WAD * rateToken1ToUsd_ / 10 ** Constants.TOKEN_ORACLE_DECIMALS)
-        );
+        // And: The usd value of the shares overflows (test-case), and no Overflow Registry.
+        uint256 assetValue = shares * totalAssets / totalSupply;
+        vm.assume(assetValue > 0);
+        uint256 minRate = type(uint256).max / assetValue / (Constants.WAD / 10 ** Constants.TOKEN_ORACLE_DECIMALS) + 1;
+        vm.assume(minRate <= type(uint256).max / Constants.WAD);
+        rateToken1ToUsd_ = bound(rateToken1ToUsd_, minRate, type(uint256).max / Constants.WAD);
 
         vm.prank(users.transmitter);
         mockOracles.token1ToUsd.transmit(int256(rateToken1ToUsd_));
@@ -74,22 +73,23 @@ contract GetValue_StandardERC4626AM_Fuzz_Test is StandardERC4626AM_Fuzz_Test {
         uint256 totalSupply,
         uint256 totalAssets
     ) public {
-        vm.assume(shares <= totalSupply);
-        vm.assume(totalSupply > 0);
+        totalSupply = bound(totalSupply, 1, type(uint256).max);
 
         // No Overflow Registry
-        vm.assume(rateToken1ToUsd_ <= type(uint256).max / Constants.WAD / 1e18);
-        // No Overflow ERC4626
-        if (totalAssets > 0) {
-            vm.assume(shares <= type(uint256).max / totalAssets);
+        rateToken1ToUsd_ = bound(rateToken1ToUsd_, 0, type(uint256).max / Constants.WAD / 1e18);
+        // A single holder can never hold more than totalSupply, and no Overflow ERC4626.
+        uint256 maxShares = totalSupply;
+        if (totalAssets > 0 && type(uint256).max / totalAssets < maxShares) {
+            maxShares = type(uint256).max / totalAssets;
         }
-        // No Overflow
+        shares = bound(shares, 0, maxShares);
 
-        if (rateToken1ToUsd_ != 0) {
-            vm.assume(
-                shares * totalAssets / totalSupply
-                    <= type(uint256).max / (Constants.WAD * rateToken1ToUsd_ / 10 ** Constants.TOKEN_ORACLE_DECIMALS)
-            );
+        // And: The usd value of the shares does not overflow.
+        uint256 assetValue = shares * totalAssets / totalSupply;
+        if (assetValue > 0) {
+            uint256 maxRate = type(uint256).max / assetValue / (Constants.WAD / 10 ** Constants.TOKEN_ORACLE_DECIMALS);
+            uint256 maxRateRegistry = type(uint256).max / Constants.WAD / 1e18;
+            rateToken1ToUsd_ = bound(rateToken1ToUsd_, 0, maxRate < maxRateRegistry ? maxRate : maxRateRegistry);
         }
 
         uint256 expectedValueInUsd = (Constants.WAD * rateToken1ToUsd_ / 10 ** Constants.TOKEN_ORACLE_DECIMALS)

--- a/test/fuzz/asset-modules/StandardERC4626AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/GetValue.fuzz.t.sol
@@ -4,11 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { StandardERC4626AM_Fuzz_Test } from "./_StandardERC4626AM.fuzz.t.sol";
-
-import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
-
 import { Constants } from "../../../utils/Constants.sol";
+import { StandardERC4626AM_Fuzz_Test } from "./_StandardERC4626AM.fuzz.t.sol";
+import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 
 /**
  * @notice Fuzz tests for the function "getValue" of contract "StandardERC4626AM".

--- a/test/fuzz/asset-modules/StandardERC4626AM/_StandardERC4626AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StandardERC4626AM/_StandardERC4626AM.fuzz.t.sol
@@ -4,10 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { Fuzz_Test } from "../../Fuzz.t.sol";
-
-import { ERC4626Mock } from "../../../utils/mocks/tokens/ERC4626Mock.sol";
 import { ERC4626AMExtension } from "../../../utils/extensions/ERC4626AMExtension.sol";
+import { ERC4626Mock } from "../../../utils/mocks/tokens/ERC4626Mock.sol";
+import { Fuzz_Test } from "../../Fuzz.t.sol";
 
 /**
  * @notice Common logic needed by all "StandardERC4626AM" fuzz tests.

--- a/test/fuzz/asset-modules/StargateAM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/AddAsset.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 import { StargateAM } from "../../../../src/asset-modules/Stargate-Finance/StargateAM.sol";
+import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "StargateAM".

--- a/test/fuzz/asset-modules/StargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -32,7 +32,7 @@ contract CalculateValueAndRiskFactors_StargateAM_Fuzz_Test is StargateAM_Fuzz_Te
         address creditor,
         uint256 underlyingAssetsAmount
     ) public {
-        // Given value do not overflow.
+        // Given: value do not overflow.
         if (underlyingAssetsAmount > 0) {
             assetRate = bound(assetRate, 0, type(uint256).max / underlyingAssetsAmount);
         }
@@ -46,7 +46,7 @@ contract CalculateValueAndRiskFactors_StargateAM_Fuzz_Test is StargateAM_Fuzz_Te
         uint256 expectedCollateralFactor = uint256(collateralFactor) * riskFactor / AssetValuationLib.ONE_4;
         uint256 expectedLiquidationFactor = uint256(liquidationFactor) * riskFactor / AssetValuationLib.ONE_4;
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         stargateAssetModule.setRiskParameters(creditor, 0, riskFactor);
 

--- a/test/fuzz/asset-modules/StargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
+import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "_calculateValueAndRiskFactors" of contract "StargateAM".

--- a/test/fuzz/asset-modules/StargateAM/Constructor.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/Constructor.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
-
 import { StargateAMExtension } from "../../../utils/extensions/StargateAMExtension.sol";
 
 /**

--- a/test/fuzz/asset-modules/StargateAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/GetRiskFactors.fuzz.t.sol
@@ -39,7 +39,7 @@ contract GetRiskFactors_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
         uint256 expectedCollateralFactor = uint256(collateralFactor) * riskFactor / AssetValuationLib.ONE_4;
         uint256 expectedLiquidationFactor = uint256(liquidationFactor) * riskFactor / AssetValuationLib.ONE_4;
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         stargateAssetModule.setRiskParameters(creditor, 0, riskFactor);
 
@@ -48,7 +48,7 @@ contract GetRiskFactors_StargateAM_Fuzz_Test is StargateAM_Fuzz_Test {
         poolMock.setToken(address(mockERC20.token1));
         stargateAssetModule.addAsset(poolId);
 
-        // And riskFactor is set for token1.
+        // And: riskFactor is set for token1.
         vm.prank(address(registry));
         erc20AM.setRiskParameters(creditor, address(mockERC20.token1), 0, 0, collateralFactor, liquidationFactor);
 

--- a/test/fuzz/asset-modules/StargateAM/GetRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/GetRiskFactors.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.sol";
+import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getRiskFactors" of contract "StargateAM".

--- a/test/fuzz/asset-modules/StargateAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/StargateAM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -4,8 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
+import { StargateAM_Fuzz_Test } from "./_StargateAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "StargateAM".

--- a/test/fuzz/asset-modules/UniswapV2AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/AddAsset.fuzz.t.sol
@@ -4,11 +4,11 @@
  */
 pragma solidity ^0.8.0;
 
+import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 import { UniswapV2AM } from "../../../utils/mocks/asset-modules/UniswapV2AM.sol";
 import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
 import { UniswapV2PairMalicious } from "../../../utils/mocks/UniswapV2/UniswapV2PairMalicious.sol";
 import { UniswapV2PairMock } from "../../../utils/mocks/UniswapV2/UniswapV2PairMock.sol";
-import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "UniswapV2AM".

--- a/test/fuzz/asset-modules/UniswapV2AM/ComputeProfitMaximizingTrade.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/ComputeProfitMaximizingTrade.fuzz.t.sol
@@ -9,6 +9,7 @@ import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "computeProfitMaximizingTrade" of contract "UniswapV2AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ComputeProfitMaximizingTrade_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -27,12 +28,13 @@ contract ComputeProfitMaximizingTrade_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_
         uint112 reserve0,
         uint112 reserve1
     ) public {
-        vm.assume(reserve0 > 10e6); //Minimum liquidity
-        vm.assume(reserve1 > 10e6); //Minimum liquidity
-        vm.assume(priceToken0 > 10e6); //Realistic prices
-        vm.assume(priceToken1 > 10e6); //Realistic prices
-
-        vm.assume(priceToken0 > type(uint256).max / reserve0);
+        //Minimum liquidity
+        reserve0 = uint112(bound(reserve0, 10e6 + 1, type(uint112).max));
+        reserve1 = uint112(bound(reserve1, 10e6 + 1, type(uint112).max));
+        //Realistic prices
+        priceToken1 = bound(priceToken1, 10e6 + 1, type(uint256).max);
+        //Arithmetic overflow (test-case).
+        priceToken0 = bound(priceToken0, type(uint256).max / reserve0 + 1, type(uint256).max);
 
         //Arithmetic overflow.
         vm.expectRevert(bytes(""));
@@ -45,12 +47,12 @@ contract ComputeProfitMaximizingTrade_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_
         uint112 reserve0,
         uint112 reserve1
     ) public {
-        vm.assume(reserve0 > 10e6); //Minimum liquidity
-        vm.assume(reserve1 > 10e6); //Minimum liquidity
-        vm.assume(priceToken0 > 10e6); //Realistic prices
-        vm.assume(priceToken1 > 10e6); //Realistic prices
-        vm.assume(priceToken0 <= type(uint256).max / reserve0); //Overflow, only with unrealistic big numbers
-        vm.assume(priceToken1 <= type(uint256).max / 997); //Overflow, only with unrealistic big priceToken1
+        //Minimum liquidity
+        reserve0 = uint112(bound(reserve0, 10e6 + 1, type(uint112).max));
+        reserve1 = uint112(bound(reserve1, 10e6 + 1, type(uint112).max));
+        //Realistic prices, overflow only with unrealistic big numbers
+        priceToken0 = bound(priceToken0, 10e6 + 1, type(uint256).max / reserve0);
+        priceToken1 = bound(priceToken1, 10e6 + 1, type(uint256).max / 997);
 
         bool token0ToToken1 = reserve0 * priceToken0 / reserve1 < priceToken1;
         uint256 invariant = uint256(reserve0) * reserve1 * 1000;
@@ -82,12 +84,12 @@ contract ComputeProfitMaximizingTrade_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_
         uint112 reserve0,
         uint112 reserve1
     ) public view {
-        vm.assume(reserve0 > 10e6); //Minimum liquidity
-        vm.assume(reserve1 > 10e6); //Minimum liquidity
-        vm.assume(priceToken0 > 10e6); //Realistic prices
-        vm.assume(priceToken1 > 10e6); //Realistic prices
-        vm.assume(priceToken0 <= type(uint256).max / reserve0); //Overflow, only with unrealistic big numbers
-        vm.assume(priceToken1 <= type(uint256).max / 997); //Overflow, only with unrealistic big priceToken1
+        //Minimum liquidity
+        reserve0 = uint112(bound(reserve0, 10e6 + 1, type(uint112).max));
+        reserve1 = uint112(bound(reserve1, 10e6 + 1, type(uint112).max));
+        //Realistic prices, overflow only with unrealistic big numbers
+        priceToken0 = bound(priceToken0, 10e6 + 1, type(uint256).max / reserve0);
+        priceToken1 = bound(priceToken1, 10e6 + 1, type(uint256).max / 997);
 
         uint256 invariant = uint256(reserve0) * reserve1 * 1000;
         vm.assume(invariant / priceToken1 / 997 <= type(uint256).max / priceToken0); //leftSide overflows when arb is from token 1 to 0, only with unrealistic numbers

--- a/test/fuzz/asset-modules/UniswapV2AM/ComputeProfitMaximizingTrade.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/ComputeProfitMaximizingTrade.fuzz.t.sol
@@ -88,8 +88,8 @@ contract ComputeProfitMaximizingTrade_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_
         reserve0 = uint112(bound(reserve0, 10e6 + 1, type(uint112).max));
         reserve1 = uint112(bound(reserve1, 10e6 + 1, type(uint112).max));
         //Realistic prices, overflow only with unrealistic big numbers
-        priceToken0 = bound(priceToken0, 10e6 + 1, type(uint256).max / reserve0);
-        priceToken1 = bound(priceToken1, 10e6 + 1, type(uint256).max / 997);
+        priceToken0 = bound(priceToken0, 10e6 + 1, type(uint96).max);
+        priceToken1 = bound(priceToken1, 10e6 + 1, type(uint96).max);
 
         uint256 invariant = uint256(reserve0) * reserve1 * 1000;
         vm.assume(invariant / priceToken1 / 997 <= type(uint256).max / priceToken0); //leftSide overflows when arb is from token 1 to 0, only with unrealistic numbers
@@ -118,13 +118,13 @@ contract ComputeProfitMaximizingTrade_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_
         uint256 maxProfit = profitArbitrage(priceTokenIn, priceTokenOut, amountIn, reserveIn, reserveOut);
 
         //Due to numerical rounding actual maximum might be deviating bit from calculated max, but must be in a range of 1%
-        vm.assume(maxProfit <= type(uint256).max / 10_001); //Prevent overflow on underlying overflows, maxProfit can still be a ridiculous big number
+        vm.assume(maxProfit <= type(uint256).max / 10_100); //Prevent overflow on underlying overflows, maxProfit can still be a ridiculous big number
         assertGe(
-            maxProfit * 10_001 / 10_000,
+            maxProfit * 10_100 / 10_000,
             profitArbitrage(priceTokenIn, priceTokenOut, amountIn * 999 / 1000, reserveIn, reserveOut)
         );
         assertGe(
-            maxProfit * 10_001 / 10_000,
+            maxProfit * 10_100 / 10_000,
             profitArbitrage(priceTokenIn, priceTokenOut, amountIn * 1001 / 1000, reserveIn, reserveOut)
         );
     }

--- a/test/fuzz/asset-modules/UniswapV2AM/ComputeTokenAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/ComputeTokenAmounts.fuzz.t.sol
@@ -9,6 +9,7 @@ import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "computeTokenAmounts" of contract "UniswapV2AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ComputeTokenAmounts_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -27,12 +28,15 @@ contract ComputeTokenAmounts_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
         uint256 totalSupply,
         uint256 liquidityAmount
     ) public view {
-        vm.assume(totalSupply > 0); // division by 0
-        vm.assume(reserve0 > 0); // division by 0
-        vm.assume(reserve1 > 0); // division by 0
-        vm.assume(liquidityAmount <= totalSupply); // single user can never hold more than totalSupply
-        vm.assume(liquidityAmount <= type(uint256).max / reserve0); // overflow, unrealistic big liquidityAmount
-        vm.assume(liquidityAmount <= type(uint256).max / reserve1); // overflow, unrealistic big liquidityAmount
+        // division by 0
+        totalSupply = bound(totalSupply, 1, type(uint256).max);
+        reserve0 = uint112(bound(reserve0, 1, type(uint112).max));
+        reserve1 = uint112(bound(reserve1, 1, type(uint112).max));
+        // single user can never hold more than totalSupply, and no overflow on unrealistic big liquidityAmount
+        uint256 maxLiquidityAmount = type(uint256).max / reserve0;
+        if (type(uint256).max / reserve1 < maxLiquidityAmount) maxLiquidityAmount = type(uint256).max / reserve1;
+        if (totalSupply < maxLiquidityAmount) maxLiquidityAmount = totalSupply;
+        liquidityAmount = bound(liquidityAmount, 0, maxLiquidityAmount);
 
         uint256 token0AmountExpected = liquidityAmount * reserve0 / totalSupply;
         uint256 token1AmountExpected = liquidityAmount * reserve1 / totalSupply;
@@ -51,13 +55,18 @@ contract ComputeTokenAmounts_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
         uint144 totalSupply, //might overflow for totalsupply bigger than 2¨^144
         uint144 liquidityAmount
     ) public {
-        vm.assume(totalSupply > 10e6); // division by 0
-        vm.assume(reserve0Last > 10e6); // division by 0
-        vm.assume(reserve1Last > 10e6); // division by 0
-        vm.assume(liquidityAmount <= totalSupply); // single user can never hold more than totalSupply
-        vm.assume(reserve0 > reserve0Last); // Uniswap accrues fees
-
-        vm.assume(uint256(reserve0) * reserve1Last / reserve0Last <= type(uint112).max); // reserve1 is max uint112 (uniswap)
+        // division by 0
+        totalSupply = uint144(bound(totalSupply, 10e6 + 1, type(uint144).max));
+        reserve0Last = uint112(bound(reserve0Last, 10e6 + 1, type(uint112).max - 1));
+        reserve1Last = uint112(bound(reserve1Last, 10e6 + 1, type(uint112).max));
+        // single user can never hold more than totalSupply
+        liquidityAmount = uint144(bound(liquidityAmount, 0, totalSupply));
+        // Uniswap accrues fees
+        // reserve1 is max uint112 (uniswap)
+        uint256 maxReserve0 = uint256(type(uint112).max) * reserve0Last / reserve1Last;
+        if (maxReserve0 > type(uint112).max) maxReserve0 = type(uint112).max;
+        vm.assume(maxReserve0 > reserve0Last);
+        reserve0 = uint112(bound(reserve0, reserve0Last + 1, maxReserve0));
         uint112 reserve1 = uint112(uint256(reserve0) * reserve1Last / reserve0Last); // pool is still balanced and fees accrued
 
         // Given: Fees are enabled

--- a/test/fuzz/asset-modules/UniswapV2AM/GetTrustedReserves.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetTrustedReserves.fuzz.t.sol
@@ -6,10 +6,12 @@ pragma solidity ^0.8.0;
 
 import { UniswapV2AM } from "../../../utils/mocks/asset-modules/UniswapV2AM.sol";
 import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
+
 /**
  * @notice Fuzz tests for the function "getTrustedReserves" of contract "UniswapV2AM".
  */
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetTrustedReserves_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -35,12 +37,12 @@ contract GetTrustedReserves_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
         uint112 reserve0,
         uint112 reserve1
     ) public {
-        vm.assume(reserve0 > 10e6); //Minimum liquidity
-        vm.assume(reserve1 > 10e6); //Minimum liquidity
-        vm.assume(priceToken0 > 10e6); //Realistic prices
-        vm.assume(priceToken1 > 10e6); //Realistic prices
-        vm.assume(priceToken0 <= type(uint256).max / reserve0); //Overflow, only with unrealistic big numbers
-        vm.assume(priceToken1 <= type(uint256).max / 997); //Overflow, only with unrealistic big priceToken1
+        //Minimum liquidity
+        reserve0 = uint112(bound(reserve0, 10e6 + 1, type(uint112).max));
+        reserve1 = uint112(bound(reserve1, 10e6 + 1, type(uint112).max));
+        //Realistic prices, overflow only with unrealistic big numbers
+        priceToken0 = bound(priceToken0, 10e6 + 1, type(uint256).max / reserve0);
+        priceToken1 = bound(priceToken1, 10e6 + 1, type(uint256).max / 997);
 
         uint256 invariant = uint256(reserve0) * reserve1 * 1000;
         vm.assume(invariant / priceToken1 / 997 <= type(uint256).max / priceToken0); //leftSide overflows when arb is from token 1 to 0, only with unrealistic numbers

--- a/test/fuzz/asset-modules/UniswapV2AM/GetTrustedTokenAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetTrustedTokenAmounts.fuzz.t.sol
@@ -11,6 +11,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "getTrustedTokenAmounts" of contract "UniswapV2AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetTrustedTokenAmounts_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -36,12 +37,15 @@ contract GetTrustedTokenAmounts_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
         uint256 liquidityAmount
     ) public {
         // Only test for balanced pool, other tests guarantee that _getTrustedReserves brings unbalanced pool into balance
-        vm.assume(liquidityAmount > 0); // division by 0
-        vm.assume(reserve0 > 0); // division by 0
-        vm.assume(reserve1 > 0); // division by 0
-        vm.assume(liquidityAmount <= totalSupply); // single user can never hold more than totalSupply
-        vm.assume(liquidityAmount <= type(uint256).max / reserve0); // overflow, unrealistic big liquidityAmount
-        vm.assume(liquidityAmount <= type(uint256).max / reserve1); // overflow, unrealistic big liquidityAmount
+        // division by 0
+        totalSupply = bound(totalSupply, 1, type(uint256).max);
+        reserve0 = uint112(bound(reserve0, 1, type(uint112).max));
+        reserve1 = uint112(bound(reserve1, 1, type(uint112).max));
+        // single user can never hold more than totalSupply, and no overflow on unrealistic big liquidityAmount
+        uint256 maxLiquidityAmount = type(uint256).max / reserve0;
+        if (type(uint256).max / reserve1 < maxLiquidityAmount) maxLiquidityAmount = type(uint256).max / reserve1;
+        if (totalSupply < maxLiquidityAmount) maxLiquidityAmount = totalSupply;
+        liquidityAmount = bound(liquidityAmount, 1, maxLiquidityAmount);
 
         // Given: The reserves in the pool are reserve0 and reserve1
         pairToken1Token2.setReserves(reserve0, reserve1);

--- a/test/fuzz/asset-modules/UniswapV2AM/GetTrustedTokenAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetTrustedTokenAmounts.fuzz.t.sol
@@ -4,9 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
+import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 import { UniswapV2AM } from "../../../utils/mocks/asset-modules/UniswapV2AM.sol";
 import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
-import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 
 /**
  * @notice Fuzz tests for the function "getTrustedTokenAmounts" of contract "UniswapV2AM".

--- a/test/fuzz/asset-modules/UniswapV2AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -56,11 +56,11 @@ contract GetUnderlyingAssetsAmounts_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Te
         assetAmount = bound(assetAmount, 0, type(uint256).max / reserve0);
         assetAmount = bound(assetAmount, 0, type(uint256).max / reserve1);
 
-        // And state is persisted/
+        // And: state is persisted/
         pairToken1Token2.setReserves(reserve0, reserve1);
         stdstore.target(address(pairToken1Token2)).sig(pairToken1Token2.totalSupply.selector).checked_write(totalSupply);
 
-        // And the pool is balanced.
+        // And: the pool is balanced.
         uint256 priceToken0 = reserve1;
         uint256 priceToken1 = reserve0;
         vm.startPrank(users.transmitter);

--- a/test/fuzz/asset-modules/UniswapV2AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -4,12 +4,10 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
-
-import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
-
-import { Constants } from "../../../utils/Constants.sol";
 import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
+import { Constants } from "../../../utils/Constants.sol";
+import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
+import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts()" of contract "UniswapV2AM".

--- a/test/fuzz/asset-modules/UniswapV2AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetValue.fuzz.t.sol
@@ -35,14 +35,12 @@ contract GetValue_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
         uint144 _rateToken1ToUsd,
         uint144 _rateToken2ToUsd
     ) public {
-        vm.assume(_token1Decimals <= 18);
-        vm.assume(_token2Decimals <= 18);
-        vm.assume(_oracleToken1ToUsdDecimals <= 18);
-        vm.assume(_oracleToken2ToUsdDecimals <= 18);
-        vm.assume(_rateToken1ToUsd > 0);
-        vm.assume(_rateToken2ToUsd > 0);
-        vm.assume(_rateToken1ToUsd <= uint256(type(int256).max));
-        vm.assume(_rateToken2ToUsd <= uint256(type(int256).max));
+        _token1Decimals = uint8(bound(_token1Decimals, 0, 18));
+        _token2Decimals = uint8(bound(_token2Decimals, 0, 18));
+        _oracleToken1ToUsdDecimals = uint8(bound(_oracleToken1ToUsdDecimals, 0, 18));
+        _oracleToken2ToUsdDecimals = uint8(bound(_oracleToken2ToUsdDecimals, 0, 18));
+        _rateToken1ToUsd = uint144(bound(_rateToken1ToUsd, 1, type(uint144).max));
+        _rateToken2ToUsd = uint144(bound(_rateToken2ToUsd, 1, type(uint144).max));
 
         // Redeploy tokens with variable amount of decimals
         mockERC20.token1 = deployToken(
@@ -54,8 +52,10 @@ contract GetValue_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
             UniswapV2PairMock(uniswapV2Factory.createPair(address(mockERC20.token2), address(mockERC20.token1)));
         uniswapV2AM.addAsset(address(pairToken1Token2));
 
-        // Mint LP
-        vm.assume(uint256(amountToken2) * amountToken1 > pairToken1Token2.MINIMUM_LIQUIDITY()); //min liquidity in uniswap pool
+        // Mint LP, above the min liquidity in the uniswap pool.
+        amountToken2 = uint112(bound(amountToken2, 1, type(uint112).max));
+        amountToken1 =
+            uint112(bound(amountToken1, pairToken1Token2.MINIMUM_LIQUIDITY() / amountToken2 + 1, type(uint112).max));
         pairToken1Token2.mint(users.tokenCreator, amountToken2, amountToken1);
 
         bool cond0 = uint256(_rateToken2ToUsd)
@@ -79,12 +79,12 @@ contract GetValue_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
         uint144 _rateToken1ToUsd,
         uint144 _rateToken2ToUsd
     ) public {
-        vm.assume(_token1Decimals <= 18);
-        vm.assume(_token2Decimals <= 18);
-        vm.assume(_oracleToken1ToUsdDecimals <= 18);
-        vm.assume(_oracleToken2ToUsdDecimals <= 18);
-        vm.assume(_rateToken1ToUsd > 0);
-        vm.assume(_rateToken2ToUsd > 0);
+        _token1Decimals = uint8(bound(_token1Decimals, 0, 18));
+        _token2Decimals = uint8(bound(_token2Decimals, 0, 18));
+        _oracleToken1ToUsdDecimals = uint8(bound(_oracleToken1ToUsdDecimals, 0, 18));
+        _oracleToken2ToUsdDecimals = uint8(bound(_oracleToken2ToUsdDecimals, 0, 18));
+        _rateToken1ToUsd = uint144(bound(_rateToken1ToUsd, 1, type(uint144).max));
+        _rateToken2ToUsd = uint144(bound(_rateToken2ToUsd, 1, type(uint144).max));
 
         // Redeploy tokens with variable amount of decimals
         mockERC20.token1 = deployToken(
@@ -96,16 +96,19 @@ contract GetValue_UniswapV2AM_Fuzz_Test is UniswapV2AM_Fuzz_Test {
             UniswapV2PairMock(uniswapV2Factory.createPair(address(mockERC20.token2), address(mockERC20.token1)));
         uniswapV2AM.addAsset(address(pairToken1Token2));
 
-        // Mint a variable amount of balanced LP, for a given amountToken2
-        vm.assume(
-            uint256(amountToken2) * uint256(_rateToken2ToUsd)
-                < type(uint256).max / 10 ** (_token1Decimals + _oracleToken1ToUsdDecimals)
-        ); //Avoid overflow of amountToken1 in next line
+        // Mint a variable amount of balanced LP, for a given amountToken2.
+        // Avoid overflow of amountToken1 in the next line, and stay above the minimum liquidity.
+        uint256 maxAmountToken2 =
+            type(uint256).max / 10 ** (_token1Decimals + _oracleToken1ToUsdDecimals) / _rateToken2ToUsd;
+        if (maxAmountToken2 > type(uint112).max) maxAmountToken2 = type(uint112).max;
+        vm.assume(maxAmountToken2 > pairToken1Token2.MINIMUM_LIQUIDITY());
+        amountToken2 = uint112(bound(amountToken2, pairToken1Token2.MINIMUM_LIQUIDITY() + 1, maxAmountToken2));
+
         uint256 amountToken1 = uint256(amountToken2) * uint256(_rateToken2ToUsd) * 10
             ** (_token1Decimals + _oracleToken1ToUsdDecimals) / _rateToken1ToUsd / 10
             ** (_token2Decimals + _oracleToken2ToUsdDecimals);
+        vm.assume(amountToken1 > 0);
         vm.assume(amountToken1 < type(uint112).max); //max reserve in Uniswap pool
-        vm.assume(amountToken2 * amountToken1 > pairToken1Token2.MINIMUM_LIQUIDITY()); //min liquidity in uniswap pool
         pairToken1Token2.mint(users.tokenCreator, amountToken2, amountToken1);
 
         //No overflows

--- a/test/fuzz/asset-modules/UniswapV2AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/GetValue.fuzz.t.sol
@@ -4,9 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
-
 import { Constants } from "../../../utils/Constants.sol";
+import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
 import { UniswapV2PairMock } from "../../../utils/mocks/UniswapV2/UniswapV2PairMock.sol";
 
 /**

--- a/test/fuzz/asset-modules/UniswapV2AM/IsAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/IsAllowed.fuzz.t.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.0;
 
 import { UniswapV2AM_Fuzz_Test } from "./_UniswapV2AM.fuzz.t.sol";
-
 import { UniswapV2PairMalicious } from "../../../utils/mocks/UniswapV2/UniswapV2PairMalicious.sol";
 import { UniswapV2PairMock } from "../../../utils/mocks/UniswapV2/UniswapV2PairMock.sol";
 

--- a/test/fuzz/asset-modules/UniswapV2AM/_UniswapV2AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV2AM/_UniswapV2AM.fuzz.t.sol
@@ -4,16 +4,14 @@
  */
 pragma solidity ^0.8.0;
 
-import { Fuzz_Test } from "../../Fuzz.t.sol";
-
-import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
-
 import { ArcadiaOracle } from "../../../utils/mocks/oracles/ArcadiaOracle.sol";
 import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
-import { UniswapV2PairMock } from "../../../utils/mocks/UniswapV2/UniswapV2PairMock.sol";
+import { Fuzz_Test } from "../../Fuzz.t.sol";
+import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 import { UniswapV2AMExtension } from "../../../utils/extensions/UniswapV2AMExtension.sol";
 import { UniswapV2FactoryMock } from "../../../utils/mocks/UniswapV2/UniswapV2FactoryMock.sol";
+import { UniswapV2PairMock } from "../../../utils/mocks/UniswapV2/UniswapV2PairMock.sol";
 
 /**
  * @notice Common logic needed by all "UniswapV2AM" fuzz tests.

--- a/test/fuzz/asset-modules/UniswapV3AM/AddAsset.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/AddAsset.fuzz.t.sol
@@ -4,9 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 import { NonfungiblePositionManagerMock } from "../../../utils/mocks/UniswapV3/NonfungiblePositionManager.sol";
 import { UniswapV3AM } from "../../../../src/asset-modules/UniswapV3/UniswapV3AM.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -36,7 +36,7 @@ contract CalculateValueAndRiskFactors_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_
         address creditor,
         uint256[2] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         assetRates[0] = bound(assetRates[0], 0, type(uint64).max);
@@ -53,7 +53,7 @@ contract CalculateValueAndRiskFactors_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_
         liquidationFactors[0] = uint16(bound(liquidationFactors[0], collateralFactors[0], AssetValuationLib.ONE_4));
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         uniV3AM.setRiskParameters(creditor, 0, riskFactor);
 

--- a/test/fuzz/asset-modules/UniswapV3AM/GetPosition.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetPosition.fuzz.t.sol
@@ -4,9 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { NonfungiblePositionManagerMock } from "../../../utils/mocks/UniswapV3/NonfungiblePositionManager.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "_getPosition" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/GetPrincipalAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetPrincipalAmounts.fuzz.t.sol
@@ -34,16 +34,8 @@ contract GetPrincipalAmounts_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint256 priceToken1
     ) public view {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        // Avoid divide by 0, which is already checked in earlier in function.
-        vm.assume(priceToken1 > 0);
-        // Function will overFlow, not realistic.
-        vm.assume(priceToken0 <= type(uint256).max / 1e28);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
 
         uint160 sqrtPriceX96 = uniV3AM.getSqrtPriceX96(priceToken0, priceToken1);
         (uint256 expectedAmount0, uint256 expectedAmount1) = LiquidityAmounts.getAmountsForLiquidity(

--- a/test/fuzz/asset-modules/UniswapV3AM/GetPrincipalAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetPrincipalAmounts.fuzz.t.sol
@@ -4,10 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getPrincipalAmounts" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetSqrtPriceX96.fuzz.t.sol
@@ -37,13 +37,10 @@ contract GetSqrtPriceX96_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
     }
 
     function testFuzz_Success_getSqrtPriceX96_Overflow(uint256 priceToken0, uint256 priceToken1) public view {
-        // Avoid divide by 0, which is already checked in earlier in function.
-        priceToken1 = bound(priceToken1, 1, type(uint256).max);
-        // Function will overFlow, not realistic.
-        priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
-
         // Cast to uint160 overflows (test-case).
-        vm.assume(priceToken0 / priceToken1 >= 2 ** 128);
+        priceToken0 = bound(priceToken0, 2 ** 128, type(uint256).max / 1e28);
+        // Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1 = bound(priceToken1, 1, priceToken0 / 2 ** 128);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);
@@ -60,7 +57,7 @@ contract GetSqrtPriceX96_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/UniswapV3AM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetSqrtPriceX96.fuzz.t.sol
@@ -56,7 +56,7 @@ contract GetSqrtPriceX96_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         // Function will overFlow, not realistic.
         priceToken0 = bound(priceToken0, 0, type(uint256).max / 1e28);
         // Cast to uint160 will overflow, not realistic.
-        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128);
+        if (priceToken1 < 2 ** 128) priceToken0 = bound(priceToken0, 0, priceToken1 * 2 ** 128 - 1);
 
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);

--- a/test/fuzz/asset-modules/UniswapV3AM/GetSqrtPriceX96.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetSqrtPriceX96.fuzz.t.sol
@@ -4,10 +4,9 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getSqrtPriceX96" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -151,12 +151,9 @@ contract GetUnderlyingAssetsAmounts_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Te
         // And: position is valid.
         position = givenValidPosition(position);
 
-        // And: there is no fee.
-        // ToDo: include fees.
+        // And: fees are the already realised fees (tokensOwed), the pool has no fee growth.
         position.feeGrowthInside0LastX128 = 0;
         position.feeGrowthInside1LastX128 = 0;
-        position.tokensOwed0 = 0;
-        position.tokensOwed1 = 0;
 
         // And: State is persisted.
         addAssetToArcadia(address(token0), int256(asset0.usdValue));
@@ -188,8 +185,16 @@ contract GetUnderlyingAssetsAmounts_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Te
             TickMath.getSqrtRatioAtTick(position.tickUpper),
             position.liquidity
         );
-        assertEq(underlyingAssetsAmounts[0], expectedUnderlyingAssetsAmount0);
-        assertEq(underlyingAssetsAmounts[1], expectedUnderlyingAssetsAmount1);
+
+        // And: fees are added to the principal, capped at the principal.
+        uint256 expectedFee0 = position.tokensOwed0 > expectedUnderlyingAssetsAmount0
+            ? expectedUnderlyingAssetsAmount0
+            : position.tokensOwed0;
+        uint256 expectedFee1 = position.tokensOwed1 > expectedUnderlyingAssetsAmount1
+            ? expectedUnderlyingAssetsAmount1
+            : position.tokensOwed1;
+        assertEq(underlyingAssetsAmounts[0], expectedUnderlyingAssetsAmount0 + expectedFee0);
+        assertEq(underlyingAssetsAmounts[1], expectedUnderlyingAssetsAmount1 + expectedFee1);
     }
 
     function testFuzz_Success_GetUnderlyingAssetsAmounts_AmountIsZero(uint96 tokenId) public view {

--- a/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -18,7 +18,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "UniswapV3AM".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(unsafe-typecast,divide-before-multiply)
 contract GetUnderlyingAssetsAmounts_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -145,7 +145,12 @@ contract GetUnderlyingAssetsAmounts_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Te
 
         // And: Cast to uint160 in _getSqrtPriceX96 does not overflow.
         if (asset1.usdValue > 0) {
-            vm.assume(asset0.usdValue / asset1.usdValue / 10 ** asset0.decimals < 2 ** 128 / 10 ** asset1.decimals);
+            uint256 maxUsdValue0 = type(uint256).max / 10 ** (46 - asset0.decimals);
+            uint256 maxRatio = 2 ** 128 / 10 ** asset1.decimals;
+            if (maxRatio < maxUsdValue0 / asset1.usdValue / 10 ** asset0.decimals) {
+                maxUsdValue0 = asset1.usdValue * maxRatio * 10 ** asset0.decimals - 1;
+            }
+            asset0.usdValue = bound(asset0.usdValue, 0, maxUsdValue0);
         }
 
         // And: position is valid.

--- a/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetUnderlyingAssetsAmounts.fuzz.t.sol
@@ -4,8 +4,6 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
 import {
@@ -14,6 +12,7 @@ import {
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import { NonfungiblePositionManagerMock } from "../../../utils/mocks/UniswapV3/NonfungiblePositionManager.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "_getUnderlyingAssetsAmounts" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetValue.fuzz.t.sol
@@ -34,8 +34,6 @@ contract GetValue_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
 
-    // ToDo: getValue with fuzzed tokensOwed and pending Fees.
-
     function testFuzz_Success_getValue_valueInUsd(TestVariables memory vars) public {
         // Check that ticks are within allowed ranges.
         vm.assume(vars.tickLower < vars.tickUpper);

--- a/test/fuzz/asset-modules/UniswapV3AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetValue.fuzz.t.sol
@@ -36,9 +36,7 @@ contract GetValue_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
 
     function testFuzz_Success_getValue_valueInUsd(TestVariables memory vars) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(vars.tickLower < vars.tickUpper);
-        vm.assume(isWithinAllowedRange(vars.tickLower));
-        vm.assume(isWithinAllowedRange(vars.tickUpper));
+        (vars.tickLower, vars.tickUpper) = givenValidTicks(vars.tickLower, vars.tickUpper);
 
         // Deploy and sort tokens.
         vars.decimals0 = bound(vars.decimals0, 6, 18);
@@ -54,22 +52,20 @@ contract GetValue_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         }
 
         // Avoid divide by 0 in next line.
-        vm.assume(vars.priceToken1 > 0);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(vars.priceToken0 / vars.priceToken1 < 2 ** 128);
+        vars.priceToken1 = uint64(bound(vars.priceToken1, 1, type(uint64).max));
         // Check that sqrtPriceX96 is within allowed Uniswap V3 ranges.
+        uint256 minPriceToken0 = (vars.priceToken1 * 10 ** (18 - vars.decimals1) - 1) / 10 ** 28 + 1;
+        vars.priceToken0 =
+            uint64(bound(vars.priceToken0, (minPriceToken0 - 1) / 10 ** (18 - vars.decimals0) + 1, type(uint64).max));
         uint160 sqrtPriceX96 = uniV3AM.getSqrtPriceX96(
             vars.priceToken0 * 10 ** (18 - vars.decimals0), vars.priceToken1 * 10 ** (18 - vars.decimals1)
         );
-
-        vm.assume(sqrtPriceX96 >= 4_295_128_739);
-        vm.assume(sqrtPriceX96 <= 1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342);
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         IUniswapV3PoolExtension pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(vars.liquidity <= pool.maxLiquidityPerTick());
+        vars.liquidity = uint80(bound(vars.liquidity, 0, pool.maxLiquidityPerTick()));
         // Mint liquidity position.
         (uint256 tokenId,,) =
             addLiquidityUniV3(pool, vars.liquidity, users.liquidityProvider, vars.tickLower, vars.tickUpper, false);

--- a/test/fuzz/asset-modules/UniswapV3AM/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/GetValue.fuzz.t.sol
@@ -4,8 +4,6 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
@@ -14,6 +12,7 @@ import {
 } from "../../../utils/fixtures/uniswap-v3/extensions/interfaces/IUniswapV3PoolExtension.sol";
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getValue" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/IsAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/IsAllowed.fuzz.t.sol
@@ -14,6 +14,7 @@ import {
 /**
  * @notice Fuzz tests for the function "isAllowed" of contract "UniswapV3AM".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IsAllowed_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -82,8 +83,8 @@ contract IsAllowed_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         public
     {
         vm.assume(lp != address(0));
-        vm.assume(maxExposureA > 0);
-        vm.assume(maxExposureB > 0);
+        maxExposureA = uint128(bound(maxExposureA, 1, type(uint128).max));
+        maxExposureB = uint128(bound(maxExposureB, 1, type(uint128).max));
 
         // Create a LP-position of two underlying assets: token1 and token2.
         ERC20 tokenA = ERC20(address(mockERC20.token1));
@@ -133,8 +134,8 @@ contract IsAllowed_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
 
     function testFuzz_Success_isAllowed_Positive(address lp, uint128 maxExposureA, uint128 maxExposureB) public {
         vm.assume(lp != address(0));
-        vm.assume(maxExposureA > 0);
-        vm.assume(maxExposureB > 0);
+        maxExposureA = uint128(bound(maxExposureA, 1, type(uint128).max));
+        maxExposureB = uint128(bound(maxExposureB, 1, type(uint128).max));
 
         // Create a LP-position of two underlying assets: token1 and token2.
         ERC20 tokenA = ERC20(address(mockERC20.token1));

--- a/test/fuzz/asset-modules/UniswapV3AM/IsAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/IsAllowed.fuzz.t.sol
@@ -4,12 +4,11 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import {
     INonfungiblePositionManagerExtension
 } from "../../../utils/fixtures/uniswap-v3/extensions/interfaces/INonfungiblePositionManagerExtension.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "isAllowed" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -57,21 +57,17 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
     ) public {
         vm.assume(unprivilegedAddress != address(registry));
 
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -93,24 +89,19 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint256 exposureUpperAssetToAsset,
         int256 amount
     ) public {
-        vm.assume(amount != 0);
-        vm.assume(amount != 1);
+        vm.assume(amount != 0 && amount != 1);
 
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -134,21 +125,17 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -169,12 +156,10 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -235,21 +220,17 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -270,12 +251,10 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -335,13 +314,11 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
@@ -374,12 +351,10 @@ contract ProcessIndirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
                 );
 
                 // Check that exposure to underlying tokens stays below maxExposures.
-                vm.assume(amount0 + initialExposure0 < maxExposure0);
-                vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-                // And: Usd exposure of underlying assets does not overflow.
-                vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-                vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+                (initialExposure0, maxExposure0) =
+                    givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+                (initialExposure1, maxExposure1) =
+                    givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
             }
 
             // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectDeposit.fuzz.t.sol
@@ -4,8 +4,6 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { AssetModule } from "../../../../src/asset-modules/abstracts/AbstractAM.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
@@ -15,6 +13,7 @@ import {
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
 import { UniswapV3AM } from "../../../../src/asset-modules/UniswapV3/UniswapV3AM.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "processIndirectDeposit" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -56,21 +56,17 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -92,12 +88,10 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -154,21 +148,17 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -189,12 +179,10 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -249,21 +237,17 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -284,12 +268,10 @@ contract ProcessIndirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Tes
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -4,8 +4,6 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
 import {
@@ -13,6 +11,7 @@ import {
 } from "../../../utils/fixtures/uniswap-v3/extensions/interfaces/IUniswapV3PoolExtension.sol";
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "ProcessIndirectWithdrawal" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
@@ -19,6 +19,7 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 /**
  * @notice Common logic needed by all "UniswapV3AM" fuzz tests.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 abstract contract UniswapV3AM_Fuzz_Test is Fuzz_Test, UniswapV3Fixture, UniswapV3AMFixture {
     /* ///////////////////////////////////////////////////////////////
                               CONSTANTS
@@ -87,20 +88,9 @@ abstract contract UniswapV3AM_Fuzz_Test is Fuzz_Test, UniswapV3Fixture, UniswapV
         pure
         returns (uint256 sqrtPriceX96)
     {
-        // Avoid divide by 0, which is already checked in earlier in function.
-        vm.assume(priceToken1 > 0);
-        // Function will overFlow, not realistic.
-        vm.assume(priceToken0 <= type(uint256).max / 10 ** 28);
-        vm.assume(priceToken1 <= type(uint256).max / 10 ** 18);
-        // Cast to uint160 will overflow, not realistic.
-        vm.assume(priceToken0 / priceToken1 < 2 ** 128);
-
-        // sqrtPriceX96 must be within ranges, or TickMath reverts.
         uint256 priceXd28 = priceToken0 * 1e28 / priceToken1;
         uint256 sqrtPriceXd14 = FixedPointMathLib.sqrt(priceXd28);
         sqrtPriceX96 = sqrtPriceXd14 * 2 ** 96 / 1e14;
-        vm.assume(sqrtPriceX96 >= 4_295_128_739);
-        vm.assume(sqrtPriceX96 <= 1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342);
     }
 
     function givenValidPosition(NonfungiblePositionManagerMock.Position memory position)
@@ -109,12 +99,11 @@ abstract contract UniswapV3AM_Fuzz_Test is Fuzz_Test, UniswapV3Fixture, UniswapV
         returns (NonfungiblePositionManagerMock.Position memory)
     {
         // Given: poolId is non zero (=position is initialised).
-        // forge-lint: disable-next-item(unsafe-typecast)
         position.poolId = uint80(bound(position.poolId, 1, type(uint80).max));
 
         // And: Ticks are within allowed ranges.
-        vm.assume(isWithinAllowedRange(position.tickLower));
-        vm.assume(isWithinAllowedRange(position.tickUpper));
+        position.tickLower = int24(bound(position.tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK));
+        position.tickUpper = int24(bound(position.tickUpper, TickMath.MIN_TICK, TickMath.MAX_TICK));
 
         return position;
     }

--- a/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
@@ -26,8 +26,7 @@ abstract contract UniswapV3AM_Fuzz_Test is Fuzz_Test, UniswapV3Fixture, UniswapV
     /////////////////////////////////////////////////////////////// */
 
     uint256 internal constant INT256_MAX = 2 ** 255 - 1;
-    // While the true minimum value of an int256 is 2 ** 255, Solidity overflows on a negation (since INT256_MAX is one less).
-    // -> This true minimum value will overflow and revert.
+    // Negating the true minimum of 2 ** 255 overflows, so this stops one below it.
     uint256 internal constant INT256_MIN = 2 ** 255 - 1;
 
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/_UniswapV3AM.fuzz.t.sol
@@ -5,16 +5,15 @@
 pragma solidity ^0.8.0;
 
 import { Base_Test } from "../../../Base.t.sol";
-import { Fuzz_Test } from "../../Fuzz.t.sol";
-import { UniswapV3Fixture } from "../../../utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol";
-import { UniswapV3AMFixture } from "../../../utils/fixtures/arcadia-accounts/UniswapV3AMFixture.f.sol";
-
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
+import { Fuzz_Test } from "../../Fuzz.t.sol";
 import {
     IUniswapV3PoolExtension
 } from "../../../utils/fixtures/uniswap-v3/extensions/interfaces/IUniswapV3PoolExtension.sol";
 import { NonfungiblePositionManagerMock } from "../../../utils/mocks/UniswapV3/NonfungiblePositionManager.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+import { UniswapV3AMFixture } from "../../../utils/fixtures/arcadia-accounts/UniswapV3AMFixture.f.sol";
+import { UniswapV3Fixture } from "../../../utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol";
 
 /**
  * @notice Common logic needed by all "UniswapV3AM" fuzz tests.

--- a/test/fuzz/asset-modules/UniswapV3AM/processDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/processDirectDeposit.fuzz.t.sol
@@ -61,21 +61,17 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         vm.assume(unprivilegedAddress != address(registry));
 
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -120,21 +116,17 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure0
     ) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -149,7 +141,8 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
 
         // Condition on which the call should revert: exposure to token0 becomes bigger than maxExposure0.
         vm.assume(amount0 > 0);
-        vm.assume(amount0 + initialExposure0 >= maxExposure0);
+        initialExposure0 =
+            uint112(bound(initialExposure0, maxExposure0 > amount0 ? maxExposure0 - amount0 : 0, type(uint112).max));
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(priceToken0), initialExposure0, maxExposure0);
@@ -171,21 +164,17 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure1
     ) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -203,7 +192,8 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
 
         // Condition on which the call should revert: exposure to token1 becomes bigger than maxExposure1.
         vm.assume(amount1 > 0);
-        vm.assume(amount1 + initialExposure1 >= maxExposure1);
+        initialExposure1 =
+            uint112(bound(initialExposure1, maxExposure1 > amount1 ? maxExposure1 - amount1 : 0, type(uint112).max));
 
         // And: Usd value of underlying asset does not overflow.
         vm.assume(amount0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
@@ -231,20 +221,18 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure1
     ) public {
         // Check that ticks are within allowed ranges.
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
         liquidity = uint128(bound(liquidity, 1, type(uint128).max));
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -265,14 +253,10 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            // vm.assume(amount0 + initialExposure0 < maxExposure0);
-            // vm.assume(amount1 + initialExposure1 < maxExposure1);
-            initialExposure0 = uint112(bound(initialExposure0, 0, maxExposure0 + amount0));
-            initialExposure1 = uint112(bound(initialExposure1, 0, maxExposure1 + amount1));
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 < type(uint112).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 < type(uint112).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint112).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint112).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -283,8 +267,13 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             // And: usd exposure to protocol below max usd exposure.
             (uint256 usdExposureProtocol,,) =
                 uniV3AM.getValue(address(creditorUsd), address(nonfungiblePositionManager), tokenId, 1);
-            vm.assume(usdExposureProtocol < type(uint112).max);
-            maxUsdExposureProtocol = uint112(bound(maxUsdExposureProtocol, 0, usdExposureProtocol));
+            maxUsdExposureProtocol = uint112(
+                bound(
+                    maxUsdExposureProtocol,
+                    0,
+                    usdExposureProtocol < type(uint112).max ? usdExposureProtocol : type(uint112).max
+                )
+            );
         }
 
         vm.prank(users.riskManager);
@@ -308,21 +297,17 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -343,12 +328,10 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -412,21 +395,17 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -447,12 +426,10 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -512,13 +489,11 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
@@ -551,12 +526,10 @@ contract ProcessDirectDeposit_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test {
                 );
 
                 // Check that exposure to underlying tokens stays below maxExposures.
-                vm.assume(amount0 + initialExposure0 < maxExposure0);
-                vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-                // And: Usd value of underlying assets does not overflow.
-                vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-                vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+                (initialExposure0, maxExposure0) =
+                    givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+                (initialExposure1, maxExposure1) =
+                    givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
             }
 
             // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/UniswapV3AM/processDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/processDirectDeposit.fuzz.t.sol
@@ -4,8 +4,6 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { AssetModule } from "../../../../src/asset-modules/abstracts/AbstractAM.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
@@ -18,6 +16,7 @@ import {
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
 import { UniswapV3AM } from "../../../../src/asset-modules/UniswapV3/UniswapV3AM.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "processDirectDeposit" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/processDirectWithdrawalfuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/processDirectWithdrawalfuzz.t.sol
@@ -56,21 +56,17 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -92,12 +88,10 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -155,21 +149,17 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -190,12 +180,10 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.
@@ -250,21 +238,17 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
-        vm.assume(tickLower < tickUpper);
-        vm.assume(isWithinAllowedRange(tickLower));
-        vm.assume(isWithinAllowedRange(tickUpper));
-
-        vm.assume(liquidity > 0);
+        (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // Calculate and check that tick current is within allowed ranges.
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         uint160 sqrtPriceX96 = uint160(calculateAndValidateRangeTickCurrent(priceToken0, priceToken1));
-        vm.assume(isWithinAllowedRange(TickMath.getTickAtSqrtRatio(sqrtPriceX96)));
 
         // Create Uniswap V3 pool initiated at tickCurrent with cardinality 300.
         pool = createPoolUniV3(address(token0), address(token1), 100, sqrtPriceX96, 300);
 
         // Check that Liquidity is within allowed ranges.
-        vm.assume(liquidity <= pool.maxLiquidityPerTick());
+        liquidity = uint128(bound(liquidity, 1, pool.maxLiquidityPerTick()));
 
         // Mint liquidity position.
         (uint256 tokenId,,) = addLiquidityUniV3(pool, liquidity, users.liquidityProvider, tickLower, tickUpper, false);
@@ -285,12 +269,10 @@ contract ProcessDirectWithdrawal_UniswapV3AM_Fuzz_Test is UniswapV3AM_Fuzz_Test 
             );
 
             // Check that exposure to underlying tokens stays below maxExposures.
-            vm.assume(amount0 + initialExposure0 < maxExposure0);
-            vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-            // And: Usd value of underlying assets does not overflow.
-            vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-            vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+            (initialExposure0, maxExposure0) =
+                givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+            (initialExposure1, maxExposure1) =
+                givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
         }
 
         // Add underlying tokens and its oracles to Arcadia.

--- a/test/fuzz/asset-modules/UniswapV3AM/processDirectWithdrawalfuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/processDirectWithdrawalfuzz.t.sol
@@ -4,7 +4,6 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
 import {
@@ -12,6 +11,7 @@ import {
 } from "../../../utils/fixtures/uniswap-v3/extensions/interfaces/IUniswapV3PoolExtension.sol";
 import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/libraries/LiquidityAmounts.sol";
 import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "processDirectWithdrawal" of contract "UniswapV3AM".

--- a/test/fuzz/asset-modules/UniswapV3AM/setProtocol.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV3AM/setProtocol.fuzz.t.sol
@@ -4,9 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
-
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
+import { UniswapV3AM_Fuzz_Test } from "./_UniswapV3AM.fuzz.t.sol";
 import { UniswapV3AMExtension } from "../../../utils/extensions/UniswapV3AMExtension.sol";
 
 /**

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/AddAssetModule.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/AddAssetModule.fuzz.t.sol
@@ -5,8 +5,8 @@
 pragma solidity ^0.8.0;
 
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
-import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz.t.sol";
 import { UniswapV4HooksRegistry } from "../../../../src/asset-modules/UniswapV4/UniswapV4HooksRegistry.sol";
+import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "AddAssetModule" of contract "UniswapV4HooksRegistry".

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/AddHooks.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/AddHooks.fuzz.t.sol
@@ -11,6 +11,7 @@ import { UniswapV4HooksRegistry } from "../../../../src/asset-modules/UniswapV4/
 /**
  * @notice Fuzz tests for the function "AddHooks" of contract "UniswapV4HooksRegistry".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddHooks_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/AddHooks.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/AddHooks.fuzz.t.sol
@@ -5,8 +5,8 @@
 pragma solidity ^0.8.0;
 
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
-import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz.t.sol";
 import { UniswapV4HooksRegistry } from "../../../../src/asset-modules/UniswapV4/UniswapV4HooksRegistry.sol";
+import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "AddHooks" of contract "UniswapV4HooksRegistry".

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetAssetModule.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetAssetModule.fuzz.t.sol
@@ -10,6 +10,7 @@ import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz
 /**
  * @notice Fuzz tests for the function "getAssetModule" of contract "UniswapV4HooksRegistry".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetAssetModule_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -39,7 +40,7 @@ contract GetAssetModule_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegist
         );
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -82,7 +83,7 @@ contract GetAssetModule_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegist
         );
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -108,7 +109,7 @@ contract GetAssetModule_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegist
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
@@ -93,8 +93,9 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_UniswapV4HooksRegistry
         uint64 assetUnit,
         uint256 usdValue
     ) public {
-        vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
-        vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
+        // MaxExposure, and no overflow on inversion.
+        deltaExposureAssetToUnderlyingAsset =
+            bound(deltaExposureAssetToUnderlyingAsset, type(int256).min + 1, type(int112).max);
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
 

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
@@ -4,6 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
+import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { PrimaryAMMock } from "../../../utils/mocks/asset-modules/PrimaryAMMock.sol";
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
@@ -12,6 +14,7 @@ import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz
 /**
  * @notice Fuzz tests for the function "getUsdValueExposureToUnderlyingAssetAfterDeposit" of contract "UniswapV4HooksRegistry".
  */
+// forge-lint: disable-next-item(mixed-case-variable,unsafe-typecast)
 contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_UniswapV4HooksRegistry_Fuzz_Test is
     UniswapV4HooksRegistry_Fuzz_Test
 {
@@ -21,7 +24,10 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_UniswapV4HooksRegistry
     /////////////////////////////////////////////////////////////// */
 
     // forge-lint: disable-next-line(mixed-case-variable)
+    OracleModuleMock internal oracleModule;
     PrimaryAMMock internal primaryAM;
+
+    uint256 internal constant PRIMARY_AM_ORACLE_ID = 999;
 
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -32,6 +38,7 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_UniswapV4HooksRegistry
 
         vm.startPrank(users.owner);
         primaryAM = new PrimaryAMMock(users.owner, address(registry), 0);
+        oracleModule = new OracleModuleMock(users.owner, address(registry));
         registry.addAssetModule(address(primaryAM));
         vm.stopPrank();
     }
@@ -39,6 +46,24 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_UniswapV4HooksRegistry
     /*//////////////////////////////////////////////////////////////
                               TESTS
     //////////////////////////////////////////////////////////////*/
+    function addMockedOracle(uint256 oracleId, uint256 rate, bytes16 baseAsset, bytes16 quoteAsset, bool active)
+        public
+    {
+        oracleModule.setOracle(oracleId, baseAsset, quoteAsset, active);
+        registry.setOracleToOracleModule(oracleId, address(oracleModule));
+        oracleModule.setRate(oracleId, rate);
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
+    function setPrimaryAMOracle(address asset, uint256 assetId, uint64 assetUnit, uint256 usdValue) public {
+        addMockedOracle(PRIMARY_AM_ORACLE_ID, usdValue, bytes16("A"), bytes16("USD"), true);
+        uint80[] memory oracleIds = new uint80[](1);
+        oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+        bool[] memory baseToQuoteAsset = new bool[](1);
+        baseToQuoteAsset[0] = true;
+        primaryAM.setAssetInformation(asset, assetId, assetUnit, BitPackingLib.pack(baseToQuoteAsset, oracleIds));
+    }
+
     function testFuzz_Revert_getUsdValueExposureToUnderlyingAssetAfterDeposit_NonAssetModule(
         address unprivilegedAddress_,
         address underlyingAsset,
@@ -65,13 +90,21 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_UniswapV4HooksRegistry
         uint96 underlyingAssetId,
         uint256 exposureAssetToUnderlyingAsset,
         int256 deltaExposureAssetToUnderlyingAsset,
+        uint64 assetUnit,
         uint256 usdValue
     ) public {
         vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
         vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        exposureAssetToUnderlyingAsset = bound(
+            exposureAssetToUnderlyingAsset, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue
+        );
+        setPrimaryAMOracle(underlyingAsset, underlyingAssetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(
@@ -105,6 +138,6 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_UniswapV4HooksRegistry
             deltaExposureAssetToUnderlyingAsset
         );
 
-        assertEq(usdExposureAssetToUnderlyingAsset, usdValue);
+        assertEq(usdExposureAssetToUnderlyingAsset, exposureAssetToUnderlyingAsset * usdValue / assetUnit);
     }
 }

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
@@ -4,6 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
+import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { PrimaryAMMock } from "../../../utils/mocks/asset-modules/PrimaryAMMock.sol";
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
@@ -12,6 +14,7 @@ import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz
 /**
  * @notice Fuzz tests for the function "getUsdValueExposureToUnderlyingAssetAfterWithdrawal" of contract "UniswapV4HooksRegistry".
  */
+// forge-lint: disable-next-item(mixed-case-variable,unsafe-typecast)
 contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is
     UniswapV4HooksRegistry_Fuzz_Test
 {
@@ -21,7 +24,10 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_UniswapV4HooksRegis
     /////////////////////////////////////////////////////////////// */
 
     // forge-lint: disable-next-line(mixed-case-variable)
+    OracleModuleMock internal oracleModule;
     PrimaryAMMock internal primaryAM;
+
+    uint256 internal constant PRIMARY_AM_ORACLE_ID = 999;
 
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -32,6 +38,7 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_UniswapV4HooksRegis
 
         vm.startPrank(users.owner);
         primaryAM = new PrimaryAMMock(users.owner, address(registry), 0);
+        oracleModule = new OracleModuleMock(users.owner, address(registry));
         registry.addAssetModule(address(primaryAM));
         vm.stopPrank();
     }
@@ -39,6 +46,24 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_UniswapV4HooksRegis
     /*//////////////////////////////////////////////////////////////
                               TESTS
     //////////////////////////////////////////////////////////////*/
+    function addMockedOracle(uint256 oracleId, uint256 rate, bytes16 baseAsset, bytes16 quoteAsset, bool active)
+        public
+    {
+        oracleModule.setOracle(oracleId, baseAsset, quoteAsset, active);
+        registry.setOracleToOracleModule(oracleId, address(oracleModule));
+        oracleModule.setRate(oracleId, rate);
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
+    function setPrimaryAMOracle(address asset, uint256 assetId, uint64 assetUnit, uint256 usdValue) public {
+        addMockedOracle(PRIMARY_AM_ORACLE_ID, usdValue, bytes16("A"), bytes16("USD"), true);
+        uint80[] memory oracleIds = new uint80[](1);
+        oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+        bool[] memory baseToQuoteAsset = new bool[](1);
+        baseToQuoteAsset[0] = true;
+        primaryAM.setAssetInformation(asset, assetId, assetUnit, BitPackingLib.pack(baseToQuoteAsset, oracleIds));
+    }
+
     function testFuzz_Revert_getUsdValueExposureToUnderlyingAssetAfterWithdrawal_NonAssetModule(
         address unprivilegedAddress_,
         address underlyingAsset,
@@ -65,13 +90,21 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_UniswapV4HooksRegis
         uint96 underlyingAssetId,
         uint256 exposureAssetToUnderlyingAsset,
         int256 deltaExposureAssetToUnderlyingAsset,
+        uint64 assetUnit,
         uint256 usdValue
     ) public {
         vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
         vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        exposureAssetToUnderlyingAsset = bound(
+            exposureAssetToUnderlyingAsset, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue
+        );
+        setPrimaryAMOracle(underlyingAsset, underlyingAssetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(
@@ -105,6 +138,6 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_UniswapV4HooksRegis
             deltaExposureAssetToUnderlyingAsset
         );
 
-        assertEq(usdExposureAssetToUnderlyingAsset, usdValue);
+        assertEq(usdExposureAssetToUnderlyingAsset, exposureAssetToUnderlyingAsset * usdValue / assetUnit);
     }
 }

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
@@ -93,8 +93,9 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_UniswapV4HooksRegis
         uint64 assetUnit,
         uint256 usdValue
     ) public {
-        vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
-        vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
+        // MaxExposure, and no overflow on inversion.
+        deltaExposureAssetToUnderlyingAsset =
+            bound(deltaExposureAssetToUnderlyingAsset, type(int256).min + 1, type(int112).max);
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
 

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetValue.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetValue.fuzz.t.sol
@@ -47,16 +47,14 @@ contract GetValue_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fuz
         vm.stopPrank();
 
         // And : Avoid divide by 0 in next line.
-        vm.assume(vars.priceToken1 > 0);
-        // And : Cast to uint160 will overflow, not realistic.
-        vm.assume(vars.priceToken0 / vars.priceToken1 < 2 ** 128);
-        // Check that sqrtPriceX96 is within allowed Uniswap V4 ranges.
+        vars.priceToken1 = uint64(bound(vars.priceToken1, 1, type(uint64).max));
+        // And : sqrtPriceX96 is within the allowed Uniswap V4 range.
+        uint256 minPriceToken0 = (vars.priceToken1 * 10 ** (18 - vars.decimals1) - 1) / 10 ** 28 + 1;
+        vars.priceToken0 =
+            uint64(bound(vars.priceToken0, (minPriceToken0 - 1) / 10 ** (18 - vars.decimals0) + 1, type(uint64).max));
         uint160 sqrtPriceX96 = uniswapV4AM.getSqrtPriceX96(
             vars.priceToken0 * 10 ** (18 - vars.decimals0), vars.priceToken1 * 10 ** (18 - vars.decimals1)
         );
-
-        vm.assume(sqrtPriceX96 >= MIN_SQRT_PRICE);
-        vm.assume(sqrtPriceX96 <= MAX_SQRT_PRICE);
 
         // And : Initialize Uniswap V4 pool initiated at tickCurrent with tickSpacing = 1.
         int24 tickSpacing = 1;

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetValuesInUsdRecursive.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/GetValuesInUsdRecursive.fuzz.t.sol
@@ -5,20 +5,25 @@
 pragma solidity ^0.8.0;
 
 import { AssetValuationLib, AssetValueAndRiskFactors } from "../../../../src/libraries/AssetValuationLib.sol";
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
+import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
 import { PrimaryAMMock } from "../../../utils/mocks/asset-modules/PrimaryAMMock.sol";
 import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "getValuesInUsdRecursive" of contract "UniswapV4HooksRegistry".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(mixed-case-variable,unsafe-typecast)
 contract GetValuesInUsdRecursive_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                              VARIABLES
     /////////////////////////////////////////////////////////////// */
 
     // forge-lint: disable-next-line(mixed-case-variable)
+    OracleModuleMock internal oracleModule;
     PrimaryAMMock internal primaryAM;
+
+    uint256 internal constant PRIMARY_AM_ORACLE_ID = 999;
 
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -29,6 +34,7 @@ contract GetValuesInUsdRecursive_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
 
         vm.startPrank(users.owner);
         primaryAM = new PrimaryAMMock(users.owner, address(registry), 0);
+        oracleModule = new OracleModuleMock(users.owner, address(registry));
         registry.addAssetModule(address(primaryAM));
         vm.stopPrank();
     }
@@ -36,6 +42,24 @@ contract GetValuesInUsdRecursive_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
     /*//////////////////////////////////////////////////////////////
                               TESTS
     //////////////////////////////////////////////////////////////*/
+    function addMockedOracle(uint256 oracleId, uint256 rate, bytes16 baseAsset, bytes16 quoteAsset, bool active)
+        public
+    {
+        oracleModule.setOracle(oracleId, baseAsset, quoteAsset, active);
+        registry.setOracleToOracleModule(oracleId, address(oracleModule));
+        oracleModule.setRate(oracleId, rate);
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
+    function setPrimaryAMOracle(address asset, uint256 assetId, uint64 assetUnit, uint256 usdValue) public {
+        addMockedOracle(PRIMARY_AM_ORACLE_ID, usdValue, bytes16("A"), bytes16("USD"), true);
+        uint80[] memory oracleIds = new uint80[](1);
+        oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+        bool[] memory baseToQuoteAsset = new bool[](1);
+        baseToQuoteAsset[0] = true;
+        primaryAM.setAssetInformation(asset, assetId, assetUnit, BitPackingLib.pack(baseToQuoteAsset, oracleIds));
+    }
+
     function testFuzz_Revert_getValuesInUsdRecursive_UnknownAsset(
         address creditor,
         address asset,
@@ -64,7 +88,8 @@ contract GetValuesInUsdRecursive_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
         address asset,
         uint96 assetId,
         uint256 assetAmount,
-        uint128 usdValue,
+        uint64 assetUnit,
+        uint256 usdValue,
         uint128 minUsdValue,
         uint112 maxExposure,
         uint16 collateralFactor,
@@ -72,11 +97,18 @@ contract GetValuesInUsdRecursive_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
     ) public {
         collateralFactor = uint16(bound(collateralFactor, 0, AssetValuationLib.ONE_4));
         liquidationFactor = uint16(bound(liquidationFactor, collateralFactor, AssetValuationLib.ONE_4));
-        usdValue = uint128(bound(usdValue, 0, type(uint128).max - 1));
-        minUsdValue = uint128(bound(minUsdValue, usdValue + 1, type(uint128).max));
 
         registry.setAssetModule(asset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow and its value stays below "minUsdValue".
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        assetAmount = bound(
+            assetAmount, 0, usdValue == 0 ? type(uint256).max : (type(uint128).max - 1) * uint256(assetUnit) / usdValue
+        );
+        uint256 assetValue = assetAmount * usdValue / assetUnit;
+        minUsdValue = uint128(bound(minUsdValue, assetValue + 1, type(uint128).max));
+        setPrimaryAMOracle(asset, assetId, assetUnit, usdValue);
 
         vm.startPrank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(
@@ -95,7 +127,7 @@ contract GetValuesInUsdRecursive_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
         AssetValueAndRiskFactors[] memory valuesAndRiskFactors =
             v4HooksRegistry.getValuesInUsdRecursive(address(creditorUsd), assetAddresses, assetIds, assetAmounts);
 
-        assertEq(valuesAndRiskFactors[0].assetValue, usdValue);
+        assertEq(valuesAndRiskFactors[0].assetValue, assetValue);
         assertEq(valuesAndRiskFactors[0].collateralFactor, collateralFactor);
         assertEq(valuesAndRiskFactors[0].liquidationFactor, liquidationFactor);
     }

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/IsAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/IsAllowed.fuzz.t.sol
@@ -10,6 +10,7 @@ import { UniswapV4HooksRegistry_Fuzz_Test } from "./_UniswapV4HooksRegistry.fuzz
 /**
  * @notice Fuzz tests for the function "isAllowed" of contract "UniswapV4HooksRegistry".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IsAllowed_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -90,7 +91,7 @@ contract IsAllowed_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fu
         );
 
         // And: Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -127,7 +128,7 @@ contract IsAllowed_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fu
         );
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);
@@ -173,7 +174,7 @@ contract IsAllowed_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4HooksRegistry_Fu
         (tickLower, tickUpper) = givenValidTicks(tickLower, tickUpper);
 
         // And : Liquidity is not-zero
-        vm.assume(liquidity > 0);
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
         bytes32 positionKey =
             keccak256(abi.encodePacked(address(positionManagerV4), tickLower, tickUpper, bytes32(uint256(tokenId))));
         poolManager.setPositionLiquidity(stablePoolKey.toId(), positionKey, liquidity);

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectDeposit.fuzz.t.sol
@@ -38,6 +38,7 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         uint256 priceToken0,
         uint256 priceToken1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         vm.assume(unprivilegedAddress != address(registry));
 
         // Given : Valid state
@@ -78,6 +79,7 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         uint112 initialExposure0,
         uint112 maxExposure0
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state, with position fully in token0 (amount0 needed in this test case)
         (uint256 tokenId, uint256 amount0,,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 2);
@@ -109,6 +111,7 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         uint112 initialExposure1,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state, with position fully in token0 (amount0 needed in this test case)
         (uint256 tokenId,, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 1);
@@ -141,17 +144,16 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 < type(uint112).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 < type(uint112).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint112).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint112).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -161,8 +163,13 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
             // And: usd exposure to protocol below max usd exposure.
             (uint256 usdExposureProtocol,,) =
                 uniswapV4AM.getValue(address(creditorUsd), address(positionManagerV4), tokenId, 1);
-            vm.assume(usdExposureProtocol < type(uint112).max);
-            maxUsdExposureProtocol = uint112(bound(maxUsdExposureProtocol, 0, usdExposureProtocol));
+            maxUsdExposureProtocol = uint112(
+                bound(
+                    maxUsdExposureProtocol,
+                    0,
+                    usdExposureProtocol < type(uint112).max ? usdExposureProtocol : type(uint112).max
+                )
+            );
         }
 
         vm.prank(users.riskManager);
@@ -188,17 +195,16 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // And : Exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -257,17 +263,16 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -328,17 +333,16 @@ contract ProcessDirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hooks
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessDirectWithdrawal.fuzz.t.sol
@@ -55,17 +55,16 @@ contract ProcessDirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -122,17 +121,16 @@ contract ProcessDirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -186,17 +184,16 @@ contract ProcessDirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Ho
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectDeposit.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectDeposit.fuzz.t.sol
@@ -38,6 +38,7 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
         uint256 priceToken1,
         uint256 exposureUpperAssetToAsset
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         vm.assume(unprivilegedAddress != address(registry));
 
         // Given : Valid state
@@ -60,9 +61,9 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
         uint256 exposureUpperAssetToAsset,
         int256 amount
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Amount not equal to 0 or 1
-        vm.assume(amount != 0);
-        vm.assume(amount != 1);
+        vm.assume(amount != 0 && amount != 1);
 
         // And : Valid state
         (uint256 tokenId,,,) = givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
@@ -88,17 +89,16 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given: Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // And:  exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // And: Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -157,17 +157,16 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -228,17 +227,16 @@ contract ProcessIndirectDeposit_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4Hoo
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd exposure of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectWithdrawal.fuzz.t.sol
+++ b/test/fuzz/asset-modules/UniswapV4HooksRegistry/ProcessIndirectWithdrawal.fuzz.t.sol
@@ -58,17 +58,16 @@ contract ProcessIndirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -126,17 +125,16 @@ contract ProcessIndirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);
@@ -193,17 +191,16 @@ contract ProcessIndirectWithdrawal_UniswapV4HooksRegistry_Fuzz_Test is UniswapV4
         uint112 maxExposure0,
         uint112 maxExposure1
     ) public {
+        (priceToken0, priceToken1) = givenValidPrices(priceToken0, priceToken1);
         // Given : Valid state
         (uint256 tokenId, uint256 amount0, uint256 amount1,) =
             givenValidPosition(liquidity, tickLower, tickUpper, priceToken0, priceToken1, 0);
 
         // Check that exposure to underlying tokens stays below maxExposures.
-        vm.assume(amount0 + initialExposure0 < maxExposure0);
-        vm.assume(amount1 + initialExposure1 < maxExposure1);
-
-        // And: Usd value of underlying assets does not overflow.
-        vm.assume(amount0 + initialExposure0 <= type(uint256).max / priceToken0 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
-        vm.assume(amount1 + initialExposure1 <= type(uint256).max / priceToken1 / 10 ** (18 - 0)); // divided by 10 ** (18 - DecimalsOracle).
+        (initialExposure0, maxExposure0) =
+            givenValidExposures(amount0, initialExposure0, maxExposure0, priceToken0, type(uint256).max);
+        (initialExposure1, maxExposure1) =
+            givenValidExposures(amount1, initialExposure1, maxExposure1, priceToken1, type(uint256).max);
 
         // Add underlying tokens and its oracles to Arcadia.
         addAssetToArcadia(address(token0), int256(uint256(priceToken0)), initialExposure0, maxExposure0);

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/Burn.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/Burn.fuzz.t.sol
@@ -86,9 +86,6 @@ contract Burn_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
         // And: Valid state.
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
 
-        // And : Owner has a non-zero balance.
-        vm.assume(positionState.amountWrapped > 0);
-
         // And: State is persisted.
         setAMState(aeroPool, positionId, poolState, positionState);
         aeroPool.setClaimables(address(wrappedAerodromeAM), fee0, fee1);

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/CalculateValueAndRiskFactors.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/CalculateValueAndRiskFactors.fuzz.t.sol
@@ -34,7 +34,7 @@ contract CalculateValueAndRiskFactors_WrappedAerodromeAM_Fuzz_Test is WrappedAer
         address creditor,
         uint256[3] memory underlyingAssetsAmounts
     ) public {
-        // Given amounts do not overflow.
+        // Given: amounts do not overflow.
         underlyingAssetsAmounts[0] = bound(underlyingAssetsAmounts[0], 0, type(uint64).max);
         underlyingAssetsAmounts[1] = bound(underlyingAssetsAmounts[1], 0, type(uint64).max);
         underlyingAssetsAmounts[2] = bound(underlyingAssetsAmounts[2], 0, type(uint64).max);
@@ -57,7 +57,7 @@ contract CalculateValueAndRiskFactors_WrappedAerodromeAM_Fuzz_Test is WrappedAer
         liquidationFactors[1] = uint16(bound(liquidationFactors[1], collateralFactors[1], AssetValuationLib.ONE_4));
         liquidationFactors[2] = uint16(bound(liquidationFactors[2], collateralFactors[2], AssetValuationLib.ONE_4));
 
-        // And riskFactor is set.
+        // And: riskFactor is set.
         vm.prank(address(registry));
         wrappedAerodromeAM.setRiskParameters(creditor, 0, riskFactor);
 
@@ -94,7 +94,7 @@ contract CalculateValueAndRiskFactors_WrappedAerodromeAM_Fuzz_Test is WrappedAer
         address creditor,
         uint256[3] memory underlyingAssetsAmounts
     ) public {
-        // And riskFactor is set.
+        // And: riskFactor is set.
         riskFactor = uint16(bound(riskFactor, 0, AssetValuationLib.ONE_4));
         vm.prank(address(registry));
         wrappedAerodromeAM.setRiskParameters(creditor, 0, riskFactor);

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/ClaimFees.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/ClaimFees.fuzz.t.sol
@@ -82,10 +82,9 @@ contract ClaimFees_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test 
         vm.assume(owner != aeroPool.poolFees());
 
         // And: Valid state.
+        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 2, type(uint128).max));
+        positionState.amountWrapped = uint128(bound(positionState.amountWrapped, 2, poolState.totalWrapped));
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
-
-        // And : Owner has a balance bigger as 1.
-        vm.assume(positionState.amountWrapped > 1);
 
         // And: State is persisted.
         setAMState(aeroPool, positionId, poolState, positionState);

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/DecreaseLiquidity.fuzz.t.sol
@@ -74,12 +74,11 @@ contract DecreaseLiquidity_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fu
         vm.assume(owner != aeroPool.poolFees());
 
         // And: Valid state.
+        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, type(uint128).max - 1));
+        positionState.amountWrapped = uint128(bound(positionState.amountWrapped, 1, poolState.totalWrapped));
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
 
-        // And : Owner has a non-zero balance.
-        vm.assume(positionState.amountWrapped > 0);
-        // And : Owner has a balance smaller as type(uint128).max.
-        vm.assume(positionState.amountWrapped < type(uint128).max);
+        // And : Owner has a non-zero balance, smaller as type(uint128).max.
 
         // And: amount withdrawn is bigger than the balance.
         amount = uint128(bound(amount, positionState.amountWrapped + 1, type(uint128).max));
@@ -118,9 +117,6 @@ contract DecreaseLiquidity_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fu
 
         // And: Valid state.
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
-
-        // And : Owner has a non-zero balance.
-        vm.assume(positionState.amountWrapped > 0);
 
         // And: State is persisted.
         setAMState(aeroPool, positionId, poolState, positionState);
@@ -213,10 +209,9 @@ contract DecreaseLiquidity_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fu
         vm.assume(owner != aeroPool.poolFees());
 
         // And: Valid state.
+        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 2, type(uint128).max));
+        positionState.amountWrapped = uint128(bound(positionState.amountWrapped, 2, poolState.totalWrapped));
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
-
-        // And : Owner has a balance bigger as 1.
-        vm.assume(positionState.amountWrapped > 1);
 
         // And : amount withdrawn is smaller as the staked balance.
         amount = uint128(bound(amount, 1, positionState.amountWrapped - 1));

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/FeesOf.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/FeesOf.fuzz.t.sol
@@ -41,9 +41,6 @@ contract FeesOf_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
         // Given : Valid state
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
 
-        // And : Account has a non-zero balance
-        vm.assume(positionState.amountWrapped > 0);
-
         // And: State is persisted.
         setAMState(aeroPool, positionId, poolState, positionState);
         aeroPool.setClaimables(address(wrappedAerodromeAM), fee0, fee1);

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/FeesOf.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/FeesOf.fuzz.t.sol
@@ -4,14 +4,13 @@
  */
 pragma solidity ^0.8.0;
 
-import { WrappedAerodromeAM_Fuzz_Test } from "./_WrappedAerodromeAM.fuzz.t.sol";
 import { FixedPointMathLib } from "../../../../lib/solmate/src/utils/FixedPointMathLib.sol";
 import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Finance/WrappedAerodromeAM.sol";
+import { WrappedAerodromeAM_Fuzz_Test } from "./_WrappedAerodromeAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "feesOf" of contract "WrappedAerodromeAM".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
 contract FeesOf_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
     using FixedPointMathLib for uint256;
 
@@ -35,24 +34,24 @@ contract FeesOf_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
         uint256 fee1,
         bool stable
     ) public {
-        // Given : Valid aeroPool
+        // Given: A pool with a valid wrapped state.
         aeroPool = createPoolAerodrome(address(asset0), address(asset1), stable);
-
-        // Given : Valid state
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
 
-        // And: State is persisted.
+        // And: That state is persisted and the pool holds claimable fees.
         setAMState(aeroPool, positionId, poolState, positionState);
         aeroPool.setClaimables(address(wrappedAerodromeAM), fee0, fee1);
 
-        // When : Calling feesOf()
+        // When: The fees of the position are read.
         (uint256 fee0_, uint256 fee1_) = wrappedAerodromeAM.feesOf(positionId);
 
-        // Then : It should return the correct value
+        // Then: The fee balance grows with the share of the position in the accrued fees.
         uint128 fee0PerLiquidity;
         uint128 fee1PerLiquidity;
         unchecked {
+            // forge-lint: disable-next-item(unsafe-typecast)
             fee0PerLiquidity = poolState.fee0PerLiquidity + uint128(fee0.mulDivDown(1e18, poolState.totalWrapped));
+            // forge-lint: disable-next-item(unsafe-typecast)
             fee1PerLiquidity = poolState.fee1PerLiquidity + uint128(fee1.mulDivDown(1e18, poolState.totalWrapped));
         }
         uint128 deltaFee0PerLiquidity;
@@ -63,7 +62,6 @@ contract FeesOf_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
         }
         uint256 deltaFee0 = uint256(positionState.amountWrapped).mulDivDown(deltaFee0PerLiquidity, 1e18);
         uint256 deltaFee1 = uint256(positionState.amountWrapped).mulDivDown(deltaFee1PerLiquidity, 1e18);
-
         assertEq(fee0_, positionState.fee0 + deltaFee0);
         assertEq(fee1_, positionState.fee1 + deltaFee1);
     }

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/GetCurrentFees.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/GetCurrentFees.fuzz.t.sol
@@ -34,14 +34,23 @@ contract GetCurrentFees_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_
         uint256 balanceOf;
     }
 
-    function givenValidPoolFeeState(PoolFeeState memory poolFeeState) public pure returns (PoolFeeState memory) {
+    function givenValidPoolFeeState(PoolFeeState memory poolFeeState, uint256 maxBalanceOf)
+        public
+        pure
+        returns (PoolFeeState memory)
+    {
         poolFeeState.supplyIndex0 = bound(poolFeeState.supplyIndex0, 0, poolFeeState.index0);
         poolFeeState.supplyIndex1 = bound(poolFeeState.supplyIndex1, 0, poolFeeState.index1);
         uint256 delta0 = poolFeeState.index0 - poolFeeState.supplyIndex0;
         uint256 delta1 = poolFeeState.index1 - poolFeeState.supplyIndex1;
 
-        if (delta0 > 0) poolFeeState.balanceOf = bound(poolFeeState.balanceOf, 0, type(uint256).max / delta0);
-        if (delta1 > 0) poolFeeState.balanceOf = bound(poolFeeState.balanceOf, 0, type(uint256).max / delta1);
+        poolFeeState.balanceOf = bound(poolFeeState.balanceOf, 1, maxBalanceOf);
+        if (delta0 > 0 && type(uint256).max / delta0 < maxBalanceOf) {
+            poolFeeState.balanceOf = bound(poolFeeState.balanceOf, 1, type(uint256).max / delta0);
+        }
+        if (delta1 > 0 && type(uint256).max / delta1 < maxBalanceOf) {
+            poolFeeState.balanceOf = bound(poolFeeState.balanceOf, 1, type(uint256).max / delta1);
+        }
         uint256 share0 = poolFeeState.balanceOf * delta0 / 1e18;
         uint256 share1 = poolFeeState.balanceOf * delta1 / 1e18;
 
@@ -77,11 +86,10 @@ contract GetCurrentFees_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_
         aeroPool = createPoolAerodrome(address(asset0), address(asset1), stable);
 
         // And : Valid aeroPool fees.
-        poolFeeState = givenValidPoolFeeState(poolFeeState);
+        poolFeeState = givenValidPoolFeeState(poolFeeState, type(uint256).max);
 
         // And : totalWrapped is bigger than 0.
         // And : totalWrapped is smaller or equal than balanceOf (invariant).
-        vm.assume(poolFeeState.balanceOf > 0);
         poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, poolFeeState.balanceOf));
 
         // And : State is persisted.
@@ -115,13 +123,11 @@ contract GetCurrentFees_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_
         // Given : Valid aeroPool.
         aeroPool = createPoolAerodrome(address(asset0), address(asset1), stable);
 
-        // And : Valid aeroPool fees.
-        poolFeeState = givenValidPoolFeeState(poolFeeState);
+        // And : Valid aeroPool fees, balanceOf fits in the uint128 totalWrapped.
+        poolFeeState = givenValidPoolFeeState(poolFeeState, type(uint128).max);
 
         // And : totalWrapped is bigger than 0.
         // And : totalWrapped is equal to balanceOf.
-        vm.assume(poolFeeState.balanceOf > 0);
-        poolFeeState.balanceOf = bound(poolFeeState.balanceOf, 1, type(uint128).max);
         poolState.totalWrapped = uint128(poolFeeState.balanceOf);
 
         // And : State is persisted.
@@ -156,7 +162,7 @@ contract GetCurrentFees_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_
         aeroPool = createPoolAerodrome(address(asset0), address(asset1), stable);
 
         // And : Valid aeroPool fees.
-        poolFeeState = givenValidPoolFeeState(poolFeeState);
+        poolFeeState = givenValidPoolFeeState(poolFeeState, type(uint256).max);
 
         // And : totalWrapped is 0.
         poolState.totalWrapped = 0;

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/GetUnderlyingAssets.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/GetUnderlyingAssets.fuzz.t.sol
@@ -23,24 +23,25 @@ contract GetUnderlyingAssets_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_
     /////////////////////////////////////////////////////////////// */
 
     function testFuzz_Success_getUnderlyingAssets(bool stable, uint96 positionId) public {
-        // Given : the aeroPool is allowed in the Registry
+        // Given: A pool that is allowed in the Registry.
         aeroPool = createPoolAerodrome(address(mockERC20.token1), address(mockERC20.stable1), stable);
         vm.prank(users.owner);
         aerodromePoolAM.addAsset(address(aeroPool));
 
-        // And : Calling addAsset()
+        // And: The pool is added as an asset.
         wrappedAerodromeAM.addAsset(address(aeroPool));
 
-        // And : Set Asset for positionId
+        // And: The position holds that pool.
         wrappedAerodromeAM.setPoolInPosition(address(aeroPool), positionId);
 
-        // When : Calling getUnderlyingAssets()
+        // When: The underlying assets of the position are read.
         bytes32 assetKey = wrappedAerodromeAM.getKeyFromAsset(address(wrappedAerodromeAM), positionId);
         bytes32[] memory underlyingAssetKeys = wrappedAerodromeAM.getUnderlyingAssets(assetKey);
 
-        // Then : Underlying assets returned should be correct
+        // Then: The pool is the first underlying asset.
         assertEq(underlyingAssetKeys[0], wrappedAerodromeAM.getKeyFromAsset(address(aeroPool), 0));
-        // Then : Asset and gauge info should be updated
+
+        // And: Both pool tokens follow in sorted order.
         if (address(mockERC20.token1) < address(mockERC20.stable1)) {
             assertEq(underlyingAssetKeys[1], wrappedAerodromeAM.getKeyFromAsset(address(mockERC20.token1), 0));
             assertEq(underlyingAssetKeys[2], wrappedAerodromeAM.getKeyFromAsset(address(mockERC20.stable1), 0));

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/IncreaseLiquidity.fuzz.t.sol
@@ -73,11 +73,11 @@ contract IncreaseLiquidity_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fu
         vm.assume(owner != address(aeroPool));
         vm.assume(owner != aeroPool.poolFees());
 
-        // And: Valid state.
+        // And: Valid state, with room to stake more.
+        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, type(uint128).max - 1));
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
 
         // And: Amount is greater than zero.
-        vm.assume(poolState.totalWrapped < type(uint128).max);
         amount = uint128(bound(amount, 1, type(uint128).max - poolState.totalWrapped));
 
         // And: State is persisted.

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/IsAllowed.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/IsAllowed.fuzz.t.sol
@@ -23,38 +23,38 @@ contract IsAllowed_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test 
     /////////////////////////////////////////////////////////////// */
 
     function testFuzz_Success_isAllowed_False_BadAsset(uint256 positionId, address randomAddress) public view {
-        // Given : randomAddress is not the stakingAM.
+        // Given: The random address is not the Asset Module.
         vm.assume(randomAddress != address(wrappedAerodromeAM));
 
-        // When : Calling isAllowed() with the input address not equal to the Stargate AM
+        // When: The isAllowed check runs for the random address.
         bool allowed = wrappedAerodromeAM.isAllowed(randomAddress, positionId);
 
-        // Then : It should return false
+        // Then: It returns false.
         assertFalse(allowed);
     }
 
     function testFuzz_Success_isAllowed_False_BadId(uint256 positionId, uint256 lastPositionId) public {
-        // Given: positionId is bigger as lastPositionId.
+        // Given: The position id is bigger than the last minted position id.
         lastPositionId = bound(lastPositionId, 0, type(uint256).max - 1);
         positionId = bound(positionId, lastPositionId + 1, type(uint256).max);
         wrappedAerodromeAM.setIdCounter(lastPositionId);
 
-        // When : Calling isAllowed()
+        // When: The isAllowed check runs for the Asset Module and that position id.
         bool allowed = wrappedAerodromeAM.isAllowed(address(wrappedAerodromeAM), positionId);
 
-        // Then : It should return true
+        // Then: It returns false.
         assertFalse(allowed);
     }
 
     function testFuzz_Success_isAllowed_True(uint256 positionId, uint256 lastPositionId) public {
-        // Given: positionId is smaller or equal as lastPositionId.
+        // Given: The position id is smaller than or equal to the last minted position id.
         positionId = bound(positionId, 0, lastPositionId);
         wrappedAerodromeAM.setIdCounter(lastPositionId);
 
-        // When : Calling isAllowed()
+        // When: The isAllowed check runs for the Asset Module and that position id.
         bool allowed = wrappedAerodromeAM.isAllowed(address(wrappedAerodromeAM), positionId);
 
-        // Then : It should return true
+        // Then: It returns true.
         assertTrue(allowed);
     }
 }

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/Mint.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/Mint.fuzz.t.sol
@@ -36,7 +36,7 @@ contract Mint_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
 
     function testFuzz_Revert_mint_PoolNotAllowed(uint128 amount, bool stable, address account_) public {
         // Given : Amount is greater than zero
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
 
         // Given : Valid aeroPool
         aeroPool = createPoolAerodrome(address(asset0), address(asset1), stable);
@@ -65,10 +65,10 @@ contract Mint_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Test {
 
         // And: Valid state.
         WrappedAerodromeAM.PositionState memory positionState;
+        poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, type(uint128).max - 1));
         (poolState, positionState, fee0, fee1) = givenValidAMState(poolState, positionState, fee0, fee1);
 
         // And: Amount staked is greater than zero.
-        vm.assume(poolState.totalWrapped < type(uint128).max);
         amount = uint128(bound(amount, 1, type(uint128).max - poolState.totalWrapped));
 
         // And: State is persisted.

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/TotalWrapped.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/TotalWrapped.fuzz.t.sol
@@ -4,9 +4,8 @@
  */
 pragma solidity ^0.8.0;
 
-import { WrappedAerodromeAM_Fuzz_Test } from "./_WrappedAerodromeAM.fuzz.t.sol";
-
 import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Finance/WrappedAerodromeAM.sol";
+import { WrappedAerodromeAM_Fuzz_Test } from "./_WrappedAerodromeAM.fuzz.t.sol";
 
 /**
  * @notice Fuzz tests for the function "totalWrapped" of contract "WrappedAerodromeAM".
@@ -25,11 +24,11 @@ contract TotalWrapped_WrappedAerodromeAM_Fuzz_Test is WrappedAerodromeAM_Fuzz_Te
     //////////////////////////////////////////////////////////////*/
 
     function testFuzz_Success_totalWrapped(WrappedAerodromeAM.PoolState memory poolState, address pool_) public {
-        // Given : PoolState is set.
+        // Given: The pool state of an arbitrary pool is seeded.
         wrappedAerodromeAM.setPoolState(pool_, poolState);
 
-        // When : Calling totalWrapped() for the specific aeroPool.
-        // Then : It should return the correct amount.
+        // When: The total wrapped amount of that pool is read.
+        // Then: The seeded amount is returned.
         assertEq(wrappedAerodromeAM.totalWrapped(pool_), poolState.totalWrapped);
     }
 }

--- a/test/fuzz/asset-modules/WrappedAerodromeAM/_WrappedAerodromeAM.fuzz.t.sol
+++ b/test/fuzz/asset-modules/WrappedAerodromeAM/_WrappedAerodromeAM.fuzz.t.sol
@@ -4,11 +4,10 @@
  */
 pragma solidity ^0.8.0;
 
-import { Fuzz_Test } from "../../Fuzz.t.sol";
 import { AerodromeFixture } from "../../../utils/fixtures/aerodrome/AerodromeFixture.f.sol";
-
 import { AerodromePoolAM } from "../../../../src/asset-modules/Aerodrome-Finance/AerodromePoolAM.sol";
 import { ERC20Mock } from "../../../utils/mocks/tokens/ERC20Mock.sol";
+import { Fuzz_Test } from "../../Fuzz.t.sol";
 import { Pool } from "../../../utils/mocks/Aerodrome/AeroPoolMock.sol";
 import { WrappedAerodromeAM } from "../../../../src/asset-modules/Aerodrome-Finance/WrappedAerodromeAM.sol";
 import { WrappedAerodromeAMExtension } from "../../../utils/extensions/WrappedAerodromeAMExtension.sol";
@@ -55,7 +54,7 @@ abstract contract WrappedAerodromeAM_Fuzz_Test is Fuzz_Test, AerodromeFixture {
         wrappedAerodromeAM.initialize();
         vm.stopPrank();
 
-        // Create a aeroPool where both assets have a a usd value equal to their amount.
+        // Create a aeroPool where both assets have a usd value equal to their amount.
         asset0 = new ERC20Mock("Asset 0", "ASSET0", 18);
         asset1 = new ERC20Mock("Asset 1", "ASSET1", 18);
         addAssetToArcadia(address(asset0), 1e18);
@@ -77,25 +76,23 @@ abstract contract WrappedAerodromeAM_Fuzz_Test is Fuzz_Test, AerodromeFixture {
         pure
         returns (WrappedAerodromeAM.PoolState memory, WrappedAerodromeAM.PositionState memory, uint256, uint256)
     {
-        // Given: more than 1 gwei is staked.
+        // Given: A non-zero amount of liquidity is wrapped.
         poolState.totalWrapped = uint128(bound(poolState.totalWrapped, 1, type(uint128).max));
 
-        // And: totalWrapped should be >= to amountWrappedForPosition (invariant).
+        // And: The position wraps at most the total wrapped amount.
         positionState.amountWrapped = uint128(bound(positionState.amountWrapped, 1, poolState.totalWrapped));
 
-        // And: deltaFeesPerLiquidity is smaller or equal as type(uint128).max (no overflow safeCastTo128).
+        // And: The accrued pool fees keep both fee accumulators within uint128.
         fee0 = bound(fee0, 0, uint256(type(uint128).max) * poolState.totalWrapped / 1e18);
         fee1 = bound(fee1, 0, uint256(type(uint128).max) * poolState.totalWrapped / 1e18);
 
-        // Calculate the new fee0PerLiquidity.
+        // And: The pool advanced its fee0 accumulator by the accrued fee0.
         uint256 deltaFee0PerLiquidity = fee0 * 1e18 / poolState.totalWrapped;
         uint128 currentFee0PerLiquidity;
         unchecked {
             currentFee0PerLiquidity = poolState.fee0PerLiquidity + uint128(deltaFee0PerLiquidity);
         }
-        // And: New fee0 does not overflow.
-        // -> fee0PerLiquidity of the position is smaller or equal to type(uint128).max (overflow).
-        // -> deltaFee0PerLiquidity * positionState.amountWrapped / 1e18 <= type(uint128).max;
+        // And: The fee0 newly earned by the position stays within uint128.
         unchecked {
             deltaFee0PerLiquidity = currentFee0PerLiquidity - positionState.fee0PerLiquidity;
         }
@@ -104,20 +101,17 @@ abstract contract WrappedAerodromeAM_Fuzz_Test is Fuzz_Test, AerodromeFixture {
         unchecked {
             positionState.fee0PerLiquidity = currentFee0PerLiquidity - uint128(deltaFee0PerLiquidity);
         }
-        // And: Previously earned fee0 for Account + new fee0 does not overflow.
-        // -> fee0 + deltaFee0 <= type(uint128).max;
+        // And: The fee0 balance of the position plus the newly earned fee0 stays within uint128.
         uint256 deltaFee0 = deltaFee0PerLiquidity * uint256(positionState.amountWrapped) / 1e18;
         positionState.fee0 = uint128(bound(positionState.fee0, 0, type(uint128).max - deltaFee0));
 
-        // Calculate the new fee1PerLiquidity.
+        // And: The pool advanced its fee1 accumulator by the accrued fee1.
         uint256 deltaFee1PerLiquidity = fee1 * 1e18 / poolState.totalWrapped;
         uint128 currentFee1PerLiquidity;
         unchecked {
             currentFee1PerLiquidity = poolState.fee1PerLiquidity + uint128(deltaFee1PerLiquidity);
         }
-        // And: New fee1 does not overflow.
-        // -> fee1PerLiquidity of the position is smaller or equal to type(uint128).max (overflow).
-        // -> deltaFee1PerLiquidity * positionState.amountWrapped / 1e18 <= type(uint128).max;
+        // And: The fee1 newly earned by the position stays within uint128.
         unchecked {
             deltaFee1PerLiquidity = currentFee1PerLiquidity - positionState.fee1PerLiquidity;
         }
@@ -126,8 +120,7 @@ abstract contract WrappedAerodromeAM_Fuzz_Test is Fuzz_Test, AerodromeFixture {
         unchecked {
             positionState.fee1PerLiquidity = currentFee1PerLiquidity - uint128(deltaFee1PerLiquidity);
         }
-        // And: Previously earned fee1 for Account + new fee1 does not overflow.
-        // -> fee1 + deltaFee1 <= type(uint128).max;
+        // And: The fee1 balance of the position plus the newly earned fee1 stays within uint128.
         uint256 deltaFee1 = deltaFee1PerLiquidity * positionState.amountWrapped / 1e18;
         positionState.fee1 = uint128(bound(positionState.fee1, 0, type(uint128).max - deltaFee1));
 

--- a/test/fuzz/oracle-modules/ChainlinkOM/GetRate.fuzz.t.sol
+++ b/test/fuzz/oracle-modules/ChainlinkOM/GetRate.fuzz.t.sol
@@ -45,8 +45,7 @@ contract GetRate_ChainlinkOM_Fuzz_Test is ChainlinkOM_Fuzz_Test {
 
     function testFuzz_Success_getRate_Overflow(uint8 decimals, uint256 rate) public {
         decimals = uint8(bound(decimals, 0, 17));
-        rate = bound(rate, type(uint256).max / 10 ** (18 - decimals) + 1, type(uint256).max);
-        vm.assume(rate <= uint256(type(int256).max));
+        rate = bound(rate, type(uint256).max / 10 ** (18 - decimals) + 1, uint256(type(int256).max));
 
         ArcadiaOracle oracle = new ArcadiaOracle(decimals, "STABLE1 / USD");
         oracle.setOffchainTransmitter(users.transmitter);
@@ -63,8 +62,9 @@ contract GetRate_ChainlinkOM_Fuzz_Test is ChainlinkOM_Fuzz_Test {
 
     function testFuzz_Success_getRate_NoOverflow(uint8 decimals, uint256 rate) public {
         decimals = uint8(bound(decimals, 0, 18));
-        rate = bound(rate, 0, type(uint256).max / 10 ** (18 - decimals));
-        vm.assume(rate <= uint256(type(int256).max));
+        uint256 maxRate = type(uint256).max / 10 ** (18 - decimals);
+        if (maxRate > uint256(type(int256).max)) maxRate = uint256(type(int256).max);
+        rate = bound(rate, 0, maxRate);
 
         ArcadiaOracle oracle = new ArcadiaOracle(decimals, "STABLE1 / USD");
         oracle.setOffchainTransmitter(users.transmitter);

--- a/test/fuzz/registries/RegistryL1/AddAsset.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/AddAsset.fuzz.t.sol
@@ -68,7 +68,7 @@ contract AddAsset_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         vm.assume(assetType > 0);
 
         // And: asset is not yet added.
-        vm.assume(registry_.inRegistry(newAsset) == false);
+        vm.assume(!registry_.inRegistry(newAsset));
 
         // When: erc20AM calls addAsset with input of address(eth)
         vm.startPrank(address(erc20AM));

--- a/test/fuzz/registries/RegistryL1/AddAsset.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/AddAsset.fuzz.t.sol
@@ -11,6 +11,7 @@ import { RegistryL1 } from "../../../../src/registries/RegistryL1.sol";
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -53,7 +54,7 @@ contract AddAsset_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
 
     function testFuzz_Revert_addAsset_OverwriteAsset2(uint96 assetType) public {
         // Given: assetType is not zero.
-        vm.assume(assetType > 0);
+        assetType = uint96(bound(assetType, 1, type(uint96).max));
 
         vm.startPrank(address(floorERC721AM));
         // When: floorERC721AM calls addAsset
@@ -65,7 +66,7 @@ contract AddAsset_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
 
     function testFuzz_Success_addAsset(uint96 assetType, address newAsset) public {
         // Given: assetType is not zero.
-        vm.assume(assetType > 0);
+        assetType = uint96(bound(assetType, 1, type(uint96).max));
 
         // And: asset is not yet added.
         vm.assume(!registry_.inRegistry(newAsset));

--- a/test/fuzz/registries/RegistryL1/BatchGetAssetTypes.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/BatchGetAssetTypes.fuzz.t.sol
@@ -10,6 +10,7 @@ import { RegistryL1_Fuzz_Test } from "./_RegistryL1.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "batchGetAssetTypes" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BatchGetAssetTypes_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -35,7 +36,7 @@ contract BatchGetAssetTypes_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     }
 
     function testFuzz_Success_batchGetAssetTypes(uint96 assetType, address asset, address assetModule) public {
-        vm.assume(assetType > 0);
+        assetType = uint96(bound(assetType, 1, type(uint96).max));
         vm.assume(!registry_.inRegistry(asset));
 
         registry_.setAssetInformation(asset, assetType, assetModule);

--- a/test/fuzz/registries/RegistryL1/BatchProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/BatchProcessDeposit.fuzz.t.sol
@@ -182,7 +182,7 @@ contract BatchProcessDeposit_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         uint112 amount
     ) public {
         amount = uint112(bound(amount, 1, type(uint112).max));
-        vm.assume(newMaxExposure <= amount);
+        newMaxExposure = uint112(bound(newMaxExposure, 0, amount));
 
         vm.prank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL1/BatchProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/BatchProcessWithdrawal.fuzz.t.sol
@@ -119,7 +119,7 @@ contract BatchProcessWithdrawal_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         address asset
     ) public {
         vm.assume(!registry_.inRegistry(asset));
-        vm.assume(amountDeposited >= amountWithdrawn);
+        amountDeposited = uint112(bound(amountDeposited, amountWithdrawn, type(uint112).max));
 
         stdstore.target(address(registry_))
             .sig(registry_.inRegistry.selector)
@@ -151,7 +151,7 @@ contract BatchProcessWithdrawal_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     ) public {
         vm.assume(!registry_.inRegistry(asset));
         amountWithdrawn = uint112(bound(amountWithdrawn, 1, type(uint112).max));
-        vm.assume(amountDeposited >= amountWithdrawn);
+        amountDeposited = uint112(bound(amountDeposited, amountWithdrawn, type(uint112).max));
 
         stdstore.target(address(registry_))
             .sig(registry_.inRegistry.selector)

--- a/test/fuzz/registries/RegistryL1/CheckOracleSequence.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/CheckOracleSequence.fuzz.t.sol
@@ -54,7 +54,7 @@ contract CheckOracleSequence_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     //////////////////////////////////////////////////////////////*/
 
     function testFuzz_Revert_checkOracleSequence_ZeroOracles(bytes32 oracleSequence) public {
-        // Given length of oracles is zero (two rightmost bits are zero)
+        // Given: length of oracles is zero (two rightmost bits are zero)
         oracleSequence = oracleSequence << 2;
 
         vm.expectRevert(RegistryErrors.Min1Oracle.selector);

--- a/test/fuzz/registries/RegistryL1/GetCollateralValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetCollateralValue.fuzz.t.sol
@@ -59,14 +59,23 @@ contract GetCollateralValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         vm.prank(creditorUsd.riskManager());
         registry_.setRiskParameters(address(creditorUsd), 0, type(uint64).max);
 
-        vm.assume(collateralFactor_ <= AssetValuationLib.ONE_4);
-        vm.assume(rateToken1ToUsd > 0);
+        collateralFactor_ = uint16(bound(collateralFactor_, 0, AssetValuationLib.ONE_4));
+        rateToken1ToUsd = int64(bound(rateToken1ToUsd, 1, type(int64).max));
 
         vm.prank(users.transmitter);
         mockOracles.token1ToUsd.transmit(rateToken1ToUsd);
 
+        // And: The usd value of the asset is non-zero.
+        amountToken1 = uint64(
+            bound(
+                amountToken1,
+                (10 ** (Constants.TOKEN_ORACLE_DECIMALS + Constants.TOKEN_DECIMALS) / Constants.WAD - 1)
+                    / uint256(int256(rateToken1ToUsd)) + 1,
+                type(uint64).max
+            )
+        );
+
         uint256 token1ValueInUsd = convertAssetToUsd(Constants.TOKEN_DECIMALS, amountToken1, oracleToken1ToUsdArr);
-        vm.assume(token1ValueInUsd > 0);
 
         vm.prank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL1/GetLiquidationValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetLiquidationValue.fuzz.t.sol
@@ -12,6 +12,7 @@ import { AssetValuationLib } from "../../../../src/libraries/AssetValuationLib.s
 /**
  * @notice Fuzz tests for the function "getLiquidationValue" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetLiquidationValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -59,14 +60,23 @@ contract GetLiquidationValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         vm.prank(creditorUsd.riskManager());
         registry_.setRiskParameters(address(creditorUsd), 0, type(uint64).max);
 
-        vm.assume(liquidationFactor_ <= AssetValuationLib.ONE_4);
-        vm.assume(rateToken1ToUsd > 0);
+        liquidationFactor_ = uint16(bound(liquidationFactor_, 0, AssetValuationLib.ONE_4));
+        rateToken1ToUsd = int64(bound(rateToken1ToUsd, 1, type(int64).max));
 
         vm.prank(users.transmitter);
         mockOracles.token1ToUsd.transmit(rateToken1ToUsd);
 
+        // And: The usd value of the asset is non-zero.
+        amountToken1 = uint64(
+            bound(
+                amountToken1,
+                (10 ** (Constants.TOKEN_ORACLE_DECIMALS + Constants.TOKEN_DECIMALS) / Constants.WAD - 1)
+                    / uint256(int256(rateToken1ToUsd)) + 1,
+                type(uint64).max
+            )
+        );
+
         uint256 token1ValueInUsd = convertAssetToUsd(Constants.TOKEN_DECIMALS, amountToken1, oracleToken1ToUsdArr);
-        vm.assume(token1ValueInUsd > 0);
 
         vm.prank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL1/GetTotalValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetTotalValue.fuzz.t.sol
@@ -53,14 +53,13 @@ contract GetTotalValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         uint256 amountToken2,
         uint8 token2Decimals
     ) public {
-        vm.assume(token2Decimals < Constants.TOKEN_ORACLE_DECIMALS);
-        vm.assume(rateToken1ToUsd <= uint256(type(int256).max));
-        vm.assume(rateToken1ToUsd > 0);
-        vm.assume(
-            amountToken2
-                > ((type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD)
-                        * 10
-                        ** Constants.TOKEN_ORACLE_DECIMALS) / 10 ** (Constants.TOKEN_ORACLE_DECIMALS - token2Decimals)
+        token2Decimals = uint8(bound(token2Decimals, 0, Constants.TOKEN_ORACLE_DECIMALS - 1));
+        rateToken1ToUsd = bound(rateToken1ToUsd, 1, uint256(type(int256).max));
+        amountToken2 = bound(
+            amountToken2,
+            ((type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD) * 10 ** Constants.TOKEN_ORACLE_DECIMALS)
+                / 10 ** (Constants.TOKEN_ORACLE_DECIMALS - token2Decimals) + 1,
+            type(uint256).max
         );
 
         ArcadiaOracle oracle = initMockedOracle(uint8(0), "LINK / USD", int256(0));
@@ -102,7 +101,7 @@ contract GetTotalValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     function testFuzz_Revert_getTotalValue_CalculateValueInNumeraireFromValueInUsdWithRateZero(uint256 amountToken2)
         public
     {
-        vm.assume(amountToken2 > 0);
+        amountToken2 = bound(amountToken2, 1, type(uint256).max);
 
         vm.startPrank(users.transmitter);
         mockOracles.token1ToUsd.transmit(int256(0));
@@ -186,19 +185,7 @@ contract GetTotalValue_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     ) public {
         rateToken1ToUsd = bound(rateToken1ToUsd, 1, type(uint256).max / 10 ** (36 - Constants.TOKEN_ORACLE_DECIMALS));
 
-        vm.assume(
-            amountToken2
-                <= type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD / 10
-                    ** (Constants.TOKEN_ORACLE_DECIMALS - Constants.TOKEN_ORACLE_DECIMALS)
-        );
-        vm.assume(
-            amountToken2
-                <= (((type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD)
-                            * 10
-                            ** Constants.TOKEN_ORACLE_DECIMALS)
-                        / 10
-                        ** Constants.TOKEN_ORACLE_DECIMALS) * 10 ** Constants.TOKEN_DECIMALS
-        );
+        amountToken2 = bound(amountToken2, 0, type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD);
 
         vm.startPrank(users.transmitter);
         mockOracles.token1ToUsd.transmit(int256(rateToken1ToUsd));

--- a/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
@@ -55,8 +55,9 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL1_Fuzz_Test i
         uint64 assetUnit,
         uint256 usdValue
     ) public {
-        vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
-        vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
+        // MaxExposure, and no overflow on inversion.
+        deltaExposureAssetToUnderlyingAsset =
+            bound(deltaExposureAssetToUnderlyingAsset, type(int256).min + 1, type(int112).max);
 
         registry_.setAssetModule(underlyingAsset, address(primaryAM));
 

--- a/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
@@ -12,6 +12,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "getUsdValueExposureToUnderlyingAssetAfterDeposit" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -51,13 +52,21 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL1_Fuzz_Test i
         uint96 underlyingAssetId,
         uint256 exposureAssetToUnderlyingAsset,
         int256 deltaExposureAssetToUnderlyingAsset,
+        uint64 assetUnit,
         uint256 usdValue
     ) public {
         vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
         vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
 
         registry_.setAssetModule(underlyingAsset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        exposureAssetToUnderlyingAsset = bound(
+            exposureAssetToUnderlyingAsset, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue
+        );
+        setPrimaryAMOracle(underlyingAsset, underlyingAssetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(
@@ -91,6 +100,6 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL1_Fuzz_Test i
             deltaExposureAssetToUnderlyingAsset
         );
 
-        assertEq(usdExposureAssetToUnderlyingAsset, usdValue);
+        assertEq(usdExposureAssetToUnderlyingAsset, exposureAssetToUnderlyingAsset * usdValue / assetUnit);
     }
 }

--- a/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
@@ -55,8 +55,9 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL1_Fuzz_Tes
         uint64 assetUnit,
         uint256 usdValue
     ) public {
-        vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
-        vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
+        // MaxExposure, and no overflow on inversion.
+        deltaExposureAssetToUnderlyingAsset =
+            bound(deltaExposureAssetToUnderlyingAsset, type(int256).min + 1, type(int112).max);
 
         registry_.setAssetModule(underlyingAsset, address(primaryAM));
 

--- a/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
@@ -12,6 +12,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "getUsdValueExposureToUnderlyingAssetAfterWithdrawal" of contract "RegistryL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -51,13 +52,21 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL1_Fuzz_Tes
         uint96 underlyingAssetId,
         uint256 exposureAssetToUnderlyingAsset,
         int256 deltaExposureAssetToUnderlyingAsset,
+        uint64 assetUnit,
         uint256 usdValue
     ) public {
         vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
         vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
 
         registry_.setAssetModule(underlyingAsset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        exposureAssetToUnderlyingAsset = bound(
+            exposureAssetToUnderlyingAsset, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue
+        );
+        setPrimaryAMOracle(underlyingAsset, underlyingAssetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(
@@ -91,6 +100,6 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL1_Fuzz_Tes
             deltaExposureAssetToUnderlyingAsset
         );
 
-        assertEq(usdExposureAssetToUnderlyingAsset, usdValue);
+        assertEq(usdExposureAssetToUnderlyingAsset, exposureAssetToUnderlyingAsset * usdValue / assetUnit);
     }
 }

--- a/test/fuzz/registries/RegistryL1/GetValuesInUsd.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetValuesInUsd.fuzz.t.sol
@@ -47,6 +47,7 @@ contract GetValuesInUsd_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         address asset,
         uint96 assetId,
         uint256 assetAmount,
+        uint64 assetUnit,
         uint256 usdValue,
         uint112 maxExposure,
         uint16 collateralFactor,
@@ -65,7 +66,12 @@ contract GetValuesInUsd_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         liquidationFactor = uint16(bound(liquidationFactor, collateralFactor, AssetValuationLib.ONE_4));
 
         registry_.setAssetModule(asset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        assetAmount = bound(assetAmount, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue);
+        setPrimaryAMOracle(asset, assetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(
@@ -82,7 +88,7 @@ contract GetValuesInUsd_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         AssetValueAndRiskFactors[] memory valuesAndRiskFactors =
             registry_.getValuesInUsd(address(creditorUsd), assetAddresses, assetIds, assetAmounts);
 
-        assertEq(valuesAndRiskFactors[0].assetValue, usdValue);
+        assertEq(valuesAndRiskFactors[0].assetValue, assetAmount * usdValue / assetUnit);
         assertEq(valuesAndRiskFactors[0].collateralFactor, collateralFactor);
         assertEq(valuesAndRiskFactors[0].liquidationFactor, liquidationFactor);
     }
@@ -91,7 +97,8 @@ contract GetValuesInUsd_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         address asset,
         uint96 assetId,
         uint256 assetAmount,
-        uint128 usdValue,
+        uint64 assetUnit,
+        uint256 usdValue,
         uint128 minUsdValue,
         uint112 maxExposure,
         uint16 collateralFactor,
@@ -99,11 +106,18 @@ contract GetValuesInUsd_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     ) public {
         collateralFactor = uint16(bound(collateralFactor, 0, AssetValuationLib.ONE_4));
         liquidationFactor = uint16(bound(liquidationFactor, collateralFactor, AssetValuationLib.ONE_4));
-        usdValue = uint128(bound(usdValue, 0, type(uint128).max - 1));
-        minUsdValue = uint128(bound(minUsdValue, usdValue + 1, type(uint128).max));
 
         registry_.setAssetModule(asset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow and its value stays below "minUsdValue".
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        assetAmount = bound(
+            assetAmount, 0, usdValue == 0 ? type(uint256).max : (type(uint128).max - 1) * uint256(assetUnit) / usdValue
+        );
+        uint256 assetValue = assetAmount * usdValue / assetUnit;
+        minUsdValue = uint128(bound(minUsdValue, assetValue + 1, type(uint128).max));
+        setPrimaryAMOracle(asset, assetId, assetUnit, usdValue);
 
         vm.startPrank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL1/GetValuesInUsdRecursive.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/GetValuesInUsdRecursive.fuzz.t.sol
@@ -52,7 +52,8 @@ contract GetValuesInUsdRecursive_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         address asset,
         uint96 assetId,
         uint256 assetAmount,
-        uint128 usdValue,
+        uint64 assetUnit,
+        uint256 usdValue,
         uint128 minUsdValue,
         uint112 maxExposure,
         uint16 collateralFactor,
@@ -60,11 +61,18 @@ contract GetValuesInUsdRecursive_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
     ) public {
         collateralFactor = uint16(bound(collateralFactor, 0, AssetValuationLib.ONE_4));
         liquidationFactor = uint16(bound(liquidationFactor, collateralFactor, AssetValuationLib.ONE_4));
-        usdValue = uint128(bound(usdValue, 0, type(uint128).max - 1));
-        minUsdValue = uint128(bound(minUsdValue, usdValue + 1, type(uint128).max));
 
         registry_.setAssetModule(asset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow and its value stays below "minUsdValue".
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        assetAmount = bound(
+            assetAmount, 0, usdValue == 0 ? type(uint256).max : (type(uint128).max - 1) * uint256(assetUnit) / usdValue
+        );
+        uint256 assetValue = assetAmount * usdValue / assetUnit;
+        minUsdValue = uint128(bound(minUsdValue, assetValue + 1, type(uint128).max));
+        setPrimaryAMOracle(asset, assetId, assetUnit, usdValue);
 
         vm.startPrank(users.riskManager);
         registry_.setRiskParametersOfPrimaryAsset(
@@ -83,7 +91,7 @@ contract GetValuesInUsdRecursive_RegistryL1_Fuzz_Test is RegistryL1_Fuzz_Test {
         AssetValueAndRiskFactors[] memory valuesAndRiskFactors =
             registry_.getValuesInUsdRecursive(address(creditorUsd), assetAddresses, assetIds, assetAmounts);
 
-        assertEq(valuesAndRiskFactors[0].assetValue, usdValue);
+        assertEq(valuesAndRiskFactors[0].assetValue, assetValue);
         assertEq(valuesAndRiskFactors[0].collateralFactor, collateralFactor);
         assertEq(valuesAndRiskFactors[0].liquidationFactor, liquidationFactor);
     }

--- a/test/fuzz/registries/RegistryL1/_RegistryL1.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL1/_RegistryL1.fuzz.t.sol
@@ -38,6 +38,8 @@ abstract contract RegistryL1_Fuzz_Test is Fuzz_Test {
 
     OracleModuleMock internal oracleModule;
 
+    uint256 internal constant PRIMARY_AM_ORACLE_ID = 999;
+
     RegistryL1Extension internal registry_;
 
     /* ///////////////////////////////////////////////////////////////
@@ -91,6 +93,7 @@ abstract contract RegistryL1_Fuzz_Test is Fuzz_Test {
         );
 
         primaryAM = new PrimaryAMMock(users.owner, address(registry_), 0);
+        oracleModule = new OracleModuleMock(users.owner, address(registry_));
         registry_.addAssetModule(address(primaryAM));
 
         derivedAM = new DerivedAMMock(users.owner, address(registry_), 0);
@@ -241,6 +244,16 @@ abstract contract RegistryL1_Fuzz_Test is Fuzz_Test {
         oracleModule.setOracle(oracleId, baseAsset, quoteAsset, active);
         registry_.setOracleToOracleModule(oracleId, address(oracleModule));
         oracleModule.setRate(oracleId, rate);
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
+    function setPrimaryAMOracle(address asset, uint256 assetId, uint64 assetUnit, uint256 usdValue) public {
+        addMockedOracle(PRIMARY_AM_ORACLE_ID, usdValue, bytes16("A"), bytes16("USD"), true);
+        uint80[] memory oracleIds = new uint80[](1);
+        oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+        bool[] memory baseToQuoteAsset = new bool[](1);
+        baseToQuoteAsset[0] = true;
+        primaryAM.setAssetInformation(asset, assetId, assetUnit, BitPackingLib.pack(baseToQuoteAsset, oracleIds));
     }
 
     function convertAssetToUsd(uint256 assetDecimals, uint256 amount, uint80[] memory oracleArr)

--- a/test/fuzz/registries/RegistryL2/AddAsset.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/AddAsset.fuzz.t.sol
@@ -12,6 +12,7 @@ import { RegistryL2 } from "../../../../src/registries/RegistryL2.sol";
  * @notice Fuzz tests for the function "addAsset" of contract "RegistryL2".
  */
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AddAsset_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -54,7 +55,7 @@ contract AddAsset_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
 
     function testFuzz_Revert_addAsset_OverwriteAsset(uint96 assetType) public {
         // Given: assetType is not zero.
-        vm.assume(assetType > 0);
+        assetType = uint96(bound(assetType, 1, type(uint96).max));
 
         vm.startPrank(address(floorERC721AM));
         // When: floorERC721AM calls addAsset
@@ -66,7 +67,7 @@ contract AddAsset_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
 
     function testFuzz_Success_addAsset(uint96 assetType, address newAsset) public {
         // Given: assetType is not zero.
-        vm.assume(assetType > 0);
+        assetType = uint96(bound(assetType, 1, type(uint96).max));
 
         // And: asset is not yet added.
         vm.assume(!registry.inRegistry(newAsset));

--- a/test/fuzz/registries/RegistryL2/AddAsset.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/AddAsset.fuzz.t.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { RegistryErrors } from "../../../../src/libraries/Errors.sol";
 import { RegistryL2_Fuzz_Test } from "./_RegistryL2.fuzz.t.sol";
 import { RegistryL2 } from "../../../../src/registries/RegistryL2.sol";
+
 /**
  * @notice Fuzz tests for the function "addAsset" of contract "RegistryL2".
  */
@@ -68,7 +69,7 @@ contract AddAsset_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         vm.assume(assetType > 0);
 
         // And: asset is not yet added.
-        vm.assume(registry.inRegistry(newAsset) == false);
+        vm.assume(!registry.inRegistry(newAsset));
 
         // When: erc20AM calls addAsset with input of address(eth)
         vm.startPrank(address(erc20AM));

--- a/test/fuzz/registries/RegistryL2/BatchGetAssetTypes.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/BatchGetAssetTypes.fuzz.t.sol
@@ -10,6 +10,7 @@ import { RegistryL2_Fuzz_Test } from "./_RegistryL2.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "batchGetAssetTypes" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BatchGetAssetTypes_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -35,7 +36,7 @@ contract BatchGetAssetTypes_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     }
 
     function testFuzz_Success_batchGetAssetTypes(uint96 assetType, address asset, address assetModule) public {
-        vm.assume(assetType > 0);
+        assetType = uint96(bound(assetType, 1, type(uint96).max));
         vm.assume(!registry.inRegistry(asset));
 
         registry.setAssetInformation(asset, assetType, assetModule);

--- a/test/fuzz/registries/RegistryL2/BatchProcessDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/BatchProcessDeposit.fuzz.t.sol
@@ -182,7 +182,7 @@ contract BatchProcessDeposit_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         uint112 amount
     ) public {
         amount = uint112(bound(amount, 1, type(uint112).max));
-        vm.assume(newMaxExposure <= amount);
+        newMaxExposure = uint112(bound(newMaxExposure, 0, amount));
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL2/BatchProcessWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/BatchProcessWithdrawal.fuzz.t.sol
@@ -119,7 +119,7 @@ contract BatchProcessWithdrawal_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         address asset
     ) public {
         vm.assume(!registry.inRegistry(asset));
-        vm.assume(amountDeposited >= amountWithdrawn);
+        amountDeposited = uint112(bound(amountDeposited, amountWithdrawn, type(uint112).max));
 
         stdstore.target(address(registry))
             .sig(registry.inRegistry.selector)
@@ -151,7 +151,7 @@ contract BatchProcessWithdrawal_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     ) public {
         vm.assume(!registry.inRegistry(asset));
         amountWithdrawn = uint112(bound(amountWithdrawn, 1, type(uint112).max));
-        vm.assume(amountDeposited >= amountWithdrawn);
+        amountDeposited = uint112(bound(amountDeposited, amountWithdrawn, type(uint112).max));
 
         stdstore.target(address(registry))
             .sig(registry.inRegistry.selector)

--- a/test/fuzz/registries/RegistryL2/CheckOracleSequence.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/CheckOracleSequence.fuzz.t.sol
@@ -54,7 +54,7 @@ contract CheckOracleSequence_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     //////////////////////////////////////////////////////////////*/
 
     function testFuzz_Revert_checkOracleSequence_ZeroOracles(bytes32 oracleSequence) public {
-        // Given length of oracles is zero (two rightmost bits are zero)
+        // Given: length of oracles is zero (two rightmost bits are zero)
         oracleSequence = oracleSequence << 2;
 
         vm.expectRevert(RegistryErrors.Min1Oracle.selector);

--- a/test/fuzz/registries/RegistryL2/GetCollateralValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetCollateralValue.fuzz.t.sol
@@ -66,6 +66,7 @@ contract GetCollateralValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         uint32 currentTime
     ) public {
         // Given: A random time.
+        currentTime = uint32(bound(currentTime, 0, type(uint32).max - 1));
         vm.warp(currentTime);
 
         // And: Sequencer is online.
@@ -73,7 +74,6 @@ contract GetCollateralValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         sequencerUptimeOracle.setLatestRoundData(0, startedAt);
 
         // And: Grace period did not pass.
-        vm.assume(currentTime - startedAt < type(uint32).max);
         gracePeriod = uint32(bound(gracePeriod, currentTime - startedAt + 1, type(uint32).max));
         vm.prank(creditorUsd.riskManager());
         registry.setRiskParameters(address(creditorUsd), 0, gracePeriod, type(uint64).max);
@@ -131,14 +131,23 @@ contract GetCollateralValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         vm.prank(creditorUsd.riskManager());
         registry.setRiskParameters(address(creditorUsd), 0, gracePeriod, type(uint64).max);
 
-        vm.assume(collateralFactor_ <= AssetValuationLib.ONE_4);
-        vm.assume(rateToken1ToUsd > 0);
+        collateralFactor_ = uint16(bound(collateralFactor_, 0, AssetValuationLib.ONE_4));
+        rateToken1ToUsd = int64(bound(rateToken1ToUsd, 1, type(int64).max));
 
         vm.prank(users.transmitter);
         mockOracles.token1ToUsd.transmit(rateToken1ToUsd);
 
+        // And: The usd value of the asset is non-zero.
+        amountToken1 = uint64(
+            bound(
+                amountToken1,
+                (10 ** (Constants.TOKEN_ORACLE_DECIMALS + Constants.TOKEN_DECIMALS) / Constants.WAD - 1)
+                    / uint256(int256(rateToken1ToUsd)) + 1,
+                type(uint64).max
+            )
+        );
+
         uint256 token1ValueInUsd = convertAssetToUsd(Constants.TOKEN_DECIMALS, amountToken1, oracleToken1ToUsdArr);
-        vm.assume(token1ValueInUsd > 0);
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL2/GetLiquidationValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetLiquidationValue.fuzz.t.sol
@@ -66,6 +66,7 @@ contract GetLiquidationValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         uint32 currentTime
     ) public {
         // Given: A random time.
+        currentTime = uint32(bound(currentTime, 0, type(uint32).max - 1));
         vm.warp(currentTime);
 
         // And: Sequencer is online.
@@ -73,7 +74,6 @@ contract GetLiquidationValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         sequencerUptimeOracle.setLatestRoundData(0, startedAt);
 
         // And: Grace period did not pass.
-        vm.assume(currentTime - startedAt < type(uint32).max);
         gracePeriod = uint32(bound(gracePeriod, currentTime - startedAt + 1, type(uint32).max));
         vm.prank(creditorUsd.riskManager());
         registry.setRiskParameters(address(creditorUsd), 0, gracePeriod, type(uint64).max);
@@ -131,14 +131,23 @@ contract GetLiquidationValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         vm.prank(creditorUsd.riskManager());
         registry.setRiskParameters(address(creditorUsd), 0, gracePeriod, type(uint64).max);
 
-        vm.assume(liquidationFactor_ <= AssetValuationLib.ONE_4);
-        vm.assume(rateToken1ToUsd > 0);
+        liquidationFactor_ = uint16(bound(liquidationFactor_, 0, AssetValuationLib.ONE_4));
+        rateToken1ToUsd = int64(bound(rateToken1ToUsd, 1, type(int64).max));
 
         vm.prank(users.transmitter);
         mockOracles.token1ToUsd.transmit(rateToken1ToUsd);
 
+        // And: The usd value of the asset is non-zero.
+        amountToken1 = uint64(
+            bound(
+                amountToken1,
+                (10 ** (Constants.TOKEN_ORACLE_DECIMALS + Constants.TOKEN_DECIMALS) / Constants.WAD - 1)
+                    / uint256(int256(rateToken1ToUsd)) + 1,
+                type(uint64).max
+            )
+        );
+
         uint256 token1ValueInUsd = convertAssetToUsd(Constants.TOKEN_DECIMALS, amountToken1, oracleToken1ToUsdArr);
-        vm.assume(token1ValueInUsd > 0);
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL2/GetTotalValue.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetTotalValue.fuzz.t.sol
@@ -68,6 +68,7 @@ contract GetTotalValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         uint32 currentTime
     ) public {
         // Given: A random time.
+        currentTime = uint32(bound(currentTime, 0, type(uint32).max - 1));
         vm.warp(currentTime);
 
         // And: Sequencer is online.
@@ -75,7 +76,6 @@ contract GetTotalValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         sequencerUptimeOracle.setLatestRoundData(0, startedAt);
 
         // And: Grace period did not pass.
-        vm.assume(currentTime - startedAt < type(uint32).max);
         gracePeriod = uint32(bound(gracePeriod, currentTime - startedAt + 1, type(uint32).max));
         vm.prank(creditorUsd.riskManager());
         registry.setRiskParameters(address(creditorUsd), 0, gracePeriod, type(uint64).max);
@@ -116,14 +116,13 @@ contract GetTotalValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         uint256 amountToken2,
         uint8 token2Decimals
     ) public {
-        vm.assume(token2Decimals < Constants.TOKEN_ORACLE_DECIMALS);
-        vm.assume(rateToken1ToUsd <= uint256(type(int256).max));
-        vm.assume(rateToken1ToUsd > 0);
-        vm.assume(
-            amountToken2
-                > ((type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD)
-                        * 10
-                        ** Constants.TOKEN_ORACLE_DECIMALS) / 10 ** (Constants.TOKEN_ORACLE_DECIMALS - token2Decimals)
+        token2Decimals = uint8(bound(token2Decimals, 0, Constants.TOKEN_ORACLE_DECIMALS - 1));
+        rateToken1ToUsd = bound(rateToken1ToUsd, 1, uint256(type(int256).max));
+        amountToken2 = bound(
+            amountToken2,
+            ((type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD) * 10 ** Constants.TOKEN_ORACLE_DECIMALS)
+                / 10 ** (Constants.TOKEN_ORACLE_DECIMALS - token2Decimals) + 1,
+            type(uint256).max
         );
 
         ArcadiaOracle oracle = initMockedOracle(uint8(0), "LINK / USD", int256(0));
@@ -165,7 +164,7 @@ contract GetTotalValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     function testFuzz_Revert_getTotalValue_CalculateValueInNumeraireFromValueInUsdWithRateZero(uint256 amountToken2)
         public
     {
-        vm.assume(amountToken2 > 0);
+        amountToken2 = bound(amountToken2, 1, type(uint256).max);
 
         vm.startPrank(users.transmitter);
         mockOracles.token1ToUsd.transmit(int256(0));
@@ -255,19 +254,7 @@ contract GetTotalValue_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     ) public {
         rateToken1ToUsd = bound(rateToken1ToUsd, 1, type(uint256).max / 10 ** (36 - Constants.TOKEN_ORACLE_DECIMALS));
 
-        vm.assume(
-            amountToken2
-                <= type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD / 10
-                    ** (Constants.TOKEN_ORACLE_DECIMALS - Constants.TOKEN_ORACLE_DECIMALS)
-        );
-        vm.assume(
-            amountToken2
-                <= (((type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD)
-                            * 10
-                            ** Constants.TOKEN_ORACLE_DECIMALS)
-                        / 10
-                        ** Constants.TOKEN_ORACLE_DECIMALS) * 10 ** Constants.TOKEN_DECIMALS
-        );
+        amountToken2 = bound(amountToken2, 0, type(uint256).max / uint256(rates.token2ToUsd) / Constants.WAD);
 
         vm.startPrank(users.transmitter);
         mockOracles.token1ToUsd.transmit(int256(rateToken1ToUsd));

--- a/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
@@ -12,6 +12,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "getUsdValueExposureToUnderlyingAssetAfterDeposit" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -51,13 +52,21 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL2_Fuzz_Test i
         uint96 underlyingAssetId,
         uint256 exposureAssetToUnderlyingAsset,
         int256 deltaExposureAssetToUnderlyingAsset,
+        uint64 assetUnit,
         uint256 usdValue
     ) public {
         vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
         vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        exposureAssetToUnderlyingAsset = bound(
+            exposureAssetToUnderlyingAsset, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue
+        );
+        setPrimaryAMOracle(underlyingAsset, underlyingAssetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(
@@ -91,6 +100,6 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL2_Fuzz_Test i
             deltaExposureAssetToUnderlyingAsset
         );
 
-        assertEq(usdExposureAssetToUnderlyingAsset, usdValue);
+        assertEq(usdExposureAssetToUnderlyingAsset, exposureAssetToUnderlyingAsset * usdValue / assetUnit);
     }
 }

--- a/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterDeposit.fuzz.t.sol
@@ -55,8 +55,9 @@ contract GetUsdValueExposureToUnderlyingAssetAfterDeposit_RegistryL2_Fuzz_Test i
         uint64 assetUnit,
         uint256 usdValue
     ) public {
-        vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
-        vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
+        // MaxExposure, and no overflow on inversion.
+        deltaExposureAssetToUnderlyingAsset =
+            bound(deltaExposureAssetToUnderlyingAsset, type(int256).min + 1, type(int112).max);
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
 

--- a/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
@@ -55,8 +55,9 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL2_Fuzz_Tes
         uint64 assetUnit,
         uint256 usdValue
     ) public {
-        vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
-        vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
+        // MaxExposure, and no overflow on inversion.
+        deltaExposureAssetToUnderlyingAsset =
+            bound(deltaExposureAssetToUnderlyingAsset, type(int256).min + 1, type(int112).max);
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
 

--- a/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetUsdValueExposureToUnderlyingAssetAfterWithdrawal.fuzz.t.sol
@@ -12,6 +12,7 @@ import { StdStorage, stdStorage } from "../../../../lib/forge-std/src/Test.sol";
 /**
  * @notice Fuzz tests for the function "getUsdValueExposureToUnderlyingAssetAfterWithdrawal" of contract "RegistryL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -51,13 +52,21 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL2_Fuzz_Tes
         uint96 underlyingAssetId,
         uint256 exposureAssetToUnderlyingAsset,
         int256 deltaExposureAssetToUnderlyingAsset,
+        uint64 assetUnit,
         uint256 usdValue
     ) public {
         vm.assume(deltaExposureAssetToUnderlyingAsset <= type(int112).max); // MaxExposure.
         vm.assume(deltaExposureAssetToUnderlyingAsset > type(int256).min); // Overflows on inversion.
 
         registry.setAssetModule(underlyingAsset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        exposureAssetToUnderlyingAsset = bound(
+            exposureAssetToUnderlyingAsset, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue
+        );
+        setPrimaryAMOracle(underlyingAsset, underlyingAssetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(
@@ -91,6 +100,6 @@ contract GetUsdValueExposureToUnderlyingAssetAfterWithdrawal_RegistryL2_Fuzz_Tes
             deltaExposureAssetToUnderlyingAsset
         );
 
-        assertEq(usdExposureAssetToUnderlyingAsset, usdValue);
+        assertEq(usdExposureAssetToUnderlyingAsset, exposureAssetToUnderlyingAsset * usdValue / assetUnit);
     }
 }

--- a/test/fuzz/registries/RegistryL2/GetValuesInNumeraire.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetValuesInNumeraire.fuzz.t.sol
@@ -66,6 +66,7 @@ contract GetValuesInNumeraire_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         uint32 currentTime
     ) public {
         // Given: A random time.
+        currentTime = uint32(bound(currentTime, 0, type(uint32).max - 1));
         vm.warp(currentTime);
 
         // And: Sequencer is online.
@@ -73,7 +74,6 @@ contract GetValuesInNumeraire_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         sequencerUptimeOracle.setLatestRoundData(0, startedAt);
 
         // And: Grace period did not pass.
-        vm.assume(currentTime - startedAt < type(uint32).max);
         gracePeriod = uint32(bound(gracePeriod, currentTime - startedAt + 1, type(uint32).max));
         vm.prank(creditorUsd.riskManager());
         registry.setRiskParameters(address(creditorUsd), 0, gracePeriod, type(uint64).max);

--- a/test/fuzz/registries/RegistryL2/GetValuesInUsd.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetValuesInUsd.fuzz.t.sol
@@ -47,6 +47,7 @@ contract GetValuesInUsd_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         address asset,
         uint96 assetId,
         uint256 assetAmount,
+        uint64 assetUnit,
         uint256 usdValue,
         uint112 maxExposure,
         uint16 collateralFactor,
@@ -72,24 +73,31 @@ contract GetValuesInUsd_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         liquidationFactor = uint16(bound(liquidationFactor, collateralFactor, AssetValuationLib.ONE_4));
 
         registry.setAssetModule(asset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow.
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        assetAmount = bound(assetAmount, 0, usdValue == 0 ? type(uint256).max : type(uint256).max / usdValue);
+        setPrimaryAMOracle(asset, assetId, assetUnit, usdValue);
 
         vm.prank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(
             address(creditorUsd), asset, assetId, maxExposure, collateralFactor, liquidationFactor
         );
 
-        address[] memory assetAddresses = new address[](1);
-        assetAddresses[0] = asset;
-        uint256[] memory assetIds = new uint256[](1);
-        assetIds[0] = assetId;
-        uint256[] memory assetAmounts = new uint256[](1);
-        assetAmounts[0] = assetAmount;
+        AssetValueAndRiskFactors[] memory valuesAndRiskFactors;
+        {
+            address[] memory assetAddresses = new address[](1);
+            assetAddresses[0] = asset;
+            uint256[] memory assetIds = new uint256[](1);
+            assetIds[0] = assetId;
+            uint256[] memory assetAmounts = new uint256[](1);
+            assetAmounts[0] = assetAmount;
 
-        AssetValueAndRiskFactors[] memory valuesAndRiskFactors =
-            registry.getValuesInUsd(address(creditorUsd), assetAddresses, assetIds, assetAmounts);
+            valuesAndRiskFactors = registry.getValuesInUsd(address(creditorUsd), assetAddresses, assetIds, assetAmounts);
+        }
 
-        assertEq(valuesAndRiskFactors[0].assetValue, usdValue);
+        assertEq(valuesAndRiskFactors[0].assetValue, assetAmount * usdValue / assetUnit);
         assertEq(valuesAndRiskFactors[0].collateralFactor, collateralFactor);
         assertEq(valuesAndRiskFactors[0].liquidationFactor, liquidationFactor);
     }
@@ -98,7 +106,8 @@ contract GetValuesInUsd_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         address asset,
         uint96 assetId,
         uint256 assetAmount,
-        uint128 usdValue,
+        uint64 assetUnit,
+        uint256 usdValue,
         uint128 minUsdValue,
         uint112 maxExposure,
         uint16 collateralFactor,
@@ -106,11 +115,18 @@ contract GetValuesInUsd_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     ) public {
         collateralFactor = uint16(bound(collateralFactor, 0, AssetValuationLib.ONE_4));
         liquidationFactor = uint16(bound(liquidationFactor, collateralFactor, AssetValuationLib.ONE_4));
-        usdValue = uint128(bound(usdValue, 0, type(uint128).max - 1));
-        minUsdValue = uint128(bound(minUsdValue, usdValue + 1, type(uint128).max));
 
         registry.setAssetModule(asset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow and its value stays below "minUsdValue".
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        assetAmount = bound(
+            assetAmount, 0, usdValue == 0 ? type(uint256).max : (type(uint128).max - 1) * uint256(assetUnit) / usdValue
+        );
+        uint256 assetValue = assetAmount * usdValue / assetUnit;
+        minUsdValue = uint128(bound(minUsdValue, assetValue + 1, type(uint128).max));
+        setPrimaryAMOracle(asset, assetId, assetUnit, usdValue);
 
         vm.startPrank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(

--- a/test/fuzz/registries/RegistryL2/GetValuesInUsdRecursive.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/GetValuesInUsdRecursive.fuzz.t.sol
@@ -52,7 +52,8 @@ contract GetValuesInUsdRecursive_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         address asset,
         uint96 assetId,
         uint256 assetAmount,
-        uint128 usdValue,
+        uint64 assetUnit,
+        uint256 usdValue,
         uint128 minUsdValue,
         uint112 maxExposure,
         uint16 collateralFactor,
@@ -60,11 +61,18 @@ contract GetValuesInUsdRecursive_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
     ) public {
         collateralFactor = uint16(bound(collateralFactor, 0, AssetValuationLib.ONE_4));
         liquidationFactor = uint16(bound(liquidationFactor, collateralFactor, AssetValuationLib.ONE_4));
-        usdValue = uint128(bound(usdValue, 0, type(uint128).max - 1));
-        minUsdValue = uint128(bound(minUsdValue, usdValue + 1, type(uint128).max));
 
         registry.setAssetModule(asset, address(primaryAM));
-        primaryAM.setUsdValue(usdValue);
+
+        // And: The asset price does not overflow and its value stays below "minUsdValue".
+        assetUnit = uint64(bound(assetUnit, 1, type(uint64).max));
+        usdValue = bound(usdValue, 0, type(uint256).max / 1e18);
+        assetAmount = bound(
+            assetAmount, 0, usdValue == 0 ? type(uint256).max : (type(uint128).max - 1) * uint256(assetUnit) / usdValue
+        );
+        uint256 assetValue = assetAmount * usdValue / assetUnit;
+        minUsdValue = uint128(bound(minUsdValue, assetValue + 1, type(uint128).max));
+        setPrimaryAMOracle(asset, assetId, assetUnit, usdValue);
 
         vm.startPrank(users.riskManager);
         registry.setRiskParametersOfPrimaryAsset(
@@ -83,7 +91,7 @@ contract GetValuesInUsdRecursive_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         AssetValueAndRiskFactors[] memory valuesAndRiskFactors =
             registry.getValuesInUsdRecursive(address(creditorUsd), assetAddresses, assetIds, assetAmounts);
 
-        assertEq(valuesAndRiskFactors[0].assetValue, usdValue);
+        assertEq(valuesAndRiskFactors[0].assetValue, assetValue);
         assertEq(valuesAndRiskFactors[0].collateralFactor, collateralFactor);
         assertEq(valuesAndRiskFactors[0].liquidationFactor, liquidationFactor);
     }

--- a/test/fuzz/registries/RegistryL2/IsSequencerDown.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/IsSequencerDown.fuzz.t.sol
@@ -49,6 +49,7 @@ contract IsSequencerDown_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         uint32 currentTime
     ) public {
         // Given: A random time.
+        currentTime = uint32(bound(currentTime, 0, type(uint32).max - 1));
         vm.warp(currentTime);
 
         // And: Sequencer is online.
@@ -56,7 +57,6 @@ contract IsSequencerDown_RegistryL2_Fuzz_Test is RegistryL2_Fuzz_Test {
         sequencerUptimeOracle.setLatestRoundData(0, startedAt);
 
         // And: Grace period did not pass.
-        vm.assume(currentTime - startedAt < type(uint32).max);
         gracePeriod = uint32(bound(gracePeriod, currentTime - startedAt + 1, type(uint32).max));
         vm.prank(creditorUsd.riskManager());
         registry.setRiskParameters(address(creditorUsd), 0, gracePeriod, type(uint64).max);

--- a/test/fuzz/registries/RegistryL2/_RegistryL2.fuzz.t.sol
+++ b/test/fuzz/registries/RegistryL2/_RegistryL2.fuzz.t.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { Fuzz_Test, Constants } from "../../Fuzz.t.sol";
 
 import { ArcadiaOracle } from "../../../utils/mocks/oracles/ArcadiaOracle.sol";
+import { BitPackingLib } from "../../../../src/libraries/BitPackingLib.sol";
 import { DerivedAMMock } from "../../../utils/mocks/asset-modules/DerivedAMMock.sol";
 import { OracleModuleMock } from "../../../utils/mocks/oracle-modules/OracleModuleMock.sol";
 import { PrimaryAMMock } from "../../../utils/mocks/asset-modules/PrimaryAMMock.sol";
@@ -30,6 +31,8 @@ abstract contract RegistryL2_Fuzz_Test is Fuzz_Test {
 
     OracleModuleMock internal oracleModule;
 
+    uint256 internal constant PRIMARY_AM_ORACLE_ID = 999;
+
     /* ///////////////////////////////////////////////////////////////
                               SETUP
     /////////////////////////////////////////////////////////////// */
@@ -39,6 +42,7 @@ abstract contract RegistryL2_Fuzz_Test is Fuzz_Test {
 
         vm.startPrank(users.owner);
         primaryAM = new PrimaryAMMock(users.owner, address(registry), 0);
+        oracleModule = new OracleModuleMock(users.owner, address(registry));
         registry.addAssetModule(address(primaryAM));
 
         derivedAM = new DerivedAMMock(users.owner, address(registry), 0);
@@ -56,6 +60,16 @@ abstract contract RegistryL2_Fuzz_Test is Fuzz_Test {
         oracleModule.setOracle(oracleId, baseAsset, quoteAsset, active);
         registry.setOracleToOracleModule(oracleId, address(oracleModule));
         oracleModule.setRate(oracleId, rate);
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function,unsafe-typecast)
+    function setPrimaryAMOracle(address asset, uint256 assetId, uint64 assetUnit, uint256 usdValue) public {
+        addMockedOracle(PRIMARY_AM_ORACLE_ID, usdValue, bytes16("A"), bytes16("USD"), true);
+        uint80[] memory oracleIds = new uint80[](1);
+        oracleIds[0] = uint80(PRIMARY_AM_ORACLE_ID);
+        bool[] memory baseToQuoteAsset = new bool[](1);
+        baseToQuoteAsset[0] = true;
+        primaryAM.setAssetInformation(asset, assetId, assetUnit, BitPackingLib.pack(baseToQuoteAsset, oracleIds));
     }
 
     function convertAssetToUsd(uint256 assetDecimals, uint256 amount, uint80[] memory oracleArr)

--- a/test/utils/Utils.t.sol
+++ b/test/utils/Utils.t.sol
@@ -27,6 +27,7 @@ contract Utils_Test is Test {
     function test_Revert_veryBadBytesReplacer_Short() public {
         bytes memory bytecode = hex"4fe34f199b19b2b4f47f68442619d555527d244f78a3297ea8";
         bytes32 target = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
+        // forge-lint: disable-next-line(too-many-digits)
         bytes32 replacement = 0x100000000000000000000000000000000000000000000000000000000000000f;
 
         vm.expectRevert();
@@ -36,6 +37,7 @@ contract Utils_Test is Test {
     function test_Revert_veryBadBytesReplacer_NoMatch() public {
         bytes memory bytecode = hex"e34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b55";
         bytes32 target = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
+        // forge-lint: disable-next-line(too-many-digits)
         bytes32 replacement = 0x100000000000000000000000000000000000000000000000000000000000000f;
 
         vm.expectRevert();
@@ -45,6 +47,7 @@ contract Utils_Test is Test {
     function test_Success_veryBadBytesReplacer_FirstByte() public view {
         bytes memory bytecode = hex"e34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b544f4f";
         bytes32 target = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
+        // forge-lint: disable-next-line(too-many-digits)
         bytes32 replacement = 0x100000000000000000000000000000000000000000000000000000000000000f;
 
         bytes memory expectedResult = hex"100000000000000000000000000000000000000000000000000000000000000f4f4f";
@@ -56,6 +59,7 @@ contract Utils_Test is Test {
     function test_Success_veryBadBytesReplacer_LastByte() public view {
         bytes memory bytecode = hex"4f4fe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54";
         bytes32 target = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
+        // forge-lint: disable-next-line(too-many-digits)
         bytes32 replacement = 0x100000000000000000000000000000000000000000000000000000000000000f;
 
         bytes memory expectedResult = hex"4f4f100000000000000000000000000000000000000000000000000000000000000f";
@@ -67,6 +71,7 @@ contract Utils_Test is Test {
     function test_Success_veryBadBytesReplacer_MiddleByte() public view {
         bytes memory bytecode = hex"4fe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b544f";
         bytes32 target = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
+        // forge-lint: disable-next-line(too-many-digits)
         bytes32 replacement = 0x100000000000000000000000000000000000000000000000000000000000000f;
 
         bytes memory expectedResult = hex"4f100000000000000000000000000000000000000000000000000000000000000f4f";

--- a/test/utils/extensions/PrimaryAMExtension.sol
+++ b/test/utils/extensions/PrimaryAMExtension.sol
@@ -9,6 +9,12 @@ import { PrimaryAM } from "../../../src/asset-modules/abstracts/AbstractPrimaryA
 abstract contract PrimaryAMExtension is PrimaryAM {
     constructor(address owner_, address registry_, uint256 assetType_) PrimaryAM(owner_, registry_, assetType_) { }
 
+    function setAssetInformation(address asset, uint256 assetId, uint64 assetUnit, bytes32 oracles) public {
+        bytes32 assetKey = _getKeyFromAsset(asset, assetId);
+        assetToInformation[assetKey].assetUnit = assetUnit;
+        assetToInformation[assetKey].oracleSequence = oracles;
+    }
+
     function setExposure(
         address creditor,
         address asset,

--- a/test/utils/fixtures/arcadia-accounts/ArcadiaAccountsFixture.f.sol
+++ b/test/utils/fixtures/arcadia-accounts/ArcadiaAccountsFixture.f.sol
@@ -20,7 +20,7 @@ import { FactoryExtension } from "../../extensions/FactoryExtension.sol";
 import { RegistryL2Extension } from "../../extensions/RegistryL2Extension.sol";
 import { SequencerUptimeOracle } from "../../mocks/oracles/SequencerUptimeOracle.sol";
 
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(reentrancy-no-eth,unsafe-typecast)
 contract ArcadiaAccountsFixture is Base_Test {
     function deployArcadiaAccounts(address merklDistributor) public {
         // Deploy the sequencer uptime oracle.

--- a/test/utils/fixtures/concentrated-liquidity/ConcentratedLiquidityFixture.f.sol
+++ b/test/utils/fixtures/concentrated-liquidity/ConcentratedLiquidityFixture.f.sol
@@ -1,0 +1,73 @@
+/**
+ * Created by Pragma Labs
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+pragma solidity ^0.8.0;
+
+import { Test } from "../../../../lib/forge-std/src/Test.sol";
+import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/TickMath.sol";
+
+// forge-lint: disable-next-item(unsafe-typecast)
+abstract contract ConcentratedLiquidityFixture is Test {
+    /*//////////////////////////////////////////////////////////////////////////
+                                   CONSTANTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    // The maximum priceToken0 / priceToken1 ratio for which sqrtPriceX96 stays below TickMath.MAX_SQRT_RATIO.
+    uint256 internal constant MAX_PRICE_RATIO = (uint256(TickMath.MAX_SQRT_RATIO) * 1e14 / 2 ** 96) ** 2 / 1e28;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function givenValidPrices(uint256 priceToken0, uint256 priceToken1)
+        public
+        pure
+        returns (uint256 priceToken0_, uint256 priceToken1_)
+    {
+        // Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1_ = bound(priceToken1, 1, type(uint256).max / 10 ** 18);
+        // Function will overFlow, not realistic.
+        uint256 maxPriceToken0 = type(uint256).max / 10 ** 28;
+        // Cast to uint160 will overflow, not realistic.
+        if (priceToken1_ < 2 ** 128) {
+            uint256 maxRatio = priceToken1_ * MAX_PRICE_RATIO;
+            if (maxRatio < maxPriceToken0) maxPriceToken0 = maxRatio;
+        }
+        // A priceXd28 of 0 puts sqrtPriceX96 below the minimum.
+        priceToken0_ = bound(priceToken0, (priceToken1_ - 1) / 10 ** 28 + 1, maxPriceToken0);
+    }
+
+    function givenValidExposures(
+        uint256 amount,
+        uint112 initialExposure,
+        uint112 maxExposure,
+        uint256 price,
+        uint256 maxUsdValue
+    ) public pure returns (uint112 initialExposure_, uint112 maxExposure_) {
+        // Usd value of the underlying asset does not overflow.
+        uint256 maxAmount = maxUsdValue / price / 10 ** 18;
+        vm.assume(amount < type(uint112).max);
+        vm.assume(amount < maxAmount);
+
+        // Exposure to the underlying asset stays below maxExposure.
+        maxExposure_ = uint112(bound(maxExposure, amount + 1, type(uint112).max));
+
+        uint256 exposureLimit = maxExposure_ - amount - 1;
+        uint256 usdLimit = maxAmount - amount - 1;
+        initialExposure_ = uint112(bound(initialExposure, 0, exposureLimit < usdLimit ? exposureLimit : usdLimit));
+    }
+
+    function givenValidTicks(int24 tickLower, int24 tickUpper)
+        public
+        pure
+        returns (int24 tickLower_, int24 tickUpper_)
+    {
+        tickLower_ = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
+        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, TickMath.MAX_TICK));
+    }
+
+    function isWithinAllowedRange(int24 tick) internal pure returns (bool) {
+        return (tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick))) <= uint256(uint24(TickMath.MAX_TICK));
+    }
+}

--- a/test/utils/fixtures/merkl/extensions/DistributorExtension.sol
+++ b/test/utils/fixtures/merkl/extensions/DistributorExtension.sol
@@ -8,6 +8,7 @@ import { Claim, Distributor } from "../../../../../lib/merkl-contracts/contracts
 
 contract DistributorExtension is Distributor {
     function setClaimed(address user, address token, uint208 amount) external {
+        // forge-lint: disable-next-item(unsafe-typecast)
         setClaimed(user, token, amount, uint48(block.timestamp), getMerkleRoot());
     }
 

--- a/test/utils/fixtures/slipstream/Slipstream.f.sol
+++ b/test/utils/fixtures/slipstream/Slipstream.f.sol
@@ -19,8 +19,15 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 import { Utils } from "../../Utils.sol";
 import { WETH9Fixture } from "../weth9/WETH9Fixture.f.sol";
 
-// forge-lint: disable-next-item(divide-before-multiply,encode-packed-collision,mixed-case-function)
+// forge-lint: disable-next-item(divide-before-multiply,encode-packed-collision,mixed-case-function,unsafe-typecast)
 contract SlipstreamFixture is WETH9Fixture, AerodromeFixture {
+    /*//////////////////////////////////////////////////////////////////////////
+                                   CONSTANTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    // The maximum priceToken0 / priceToken1 ratio for which sqrtPriceX96 stays below TickMath.MAX_SQRT_RATIO.
+    uint256 internal constant MAX_PRICE_RATIO = (uint256(TickMath.MAX_SQRT_RATIO) * 1e14 / 2 ** 96) ** 2 / 1e28;
+
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -296,5 +303,43 @@ contract SlipstreamFixture is WETH9Fixture, AerodromeFixture {
                 feeGrowthInside1X128 = upperFeeGrowthOutside1X128 - lowerFeeGrowthOutside1X128;
             }
         }
+    }
+
+    function givenValidPrices(uint256 priceToken0, uint256 priceToken1)
+        public
+        pure
+        returns (uint256 priceToken0_, uint256 priceToken1_)
+    {
+        // Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1_ = bound(priceToken1, 1, type(uint256).max / 10 ** 18);
+        // Function will overFlow, not realistic.
+        uint256 maxPriceToken0 = type(uint256).max / 10 ** 28;
+        // Cast to uint160 will overflow, not realistic.
+        if (priceToken1_ < 2 ** 128) {
+            uint256 maxRatio = priceToken1_ * MAX_PRICE_RATIO;
+            if (maxRatio < maxPriceToken0) maxPriceToken0 = maxRatio;
+        }
+        // A priceXd28 of 0 puts sqrtPriceX96 below the minimum.
+        priceToken0_ = bound(priceToken0, (priceToken1_ - 1) / 10 ** 28 + 1, maxPriceToken0);
+    }
+
+    function givenValidExposures(
+        uint256 amount,
+        uint112 initialExposure,
+        uint112 maxExposure,
+        uint256 price,
+        uint256 maxUsdValue
+    ) public pure returns (uint112 initialExposure_, uint112 maxExposure_) {
+        // Usd value of the underlying asset does not overflow.
+        uint256 maxAmount = maxUsdValue / price / 10 ** 18;
+        vm.assume(amount < type(uint112).max);
+        vm.assume(amount < maxAmount);
+
+        // Exposure to the underlying asset stays below maxExposure.
+        maxExposure_ = uint112(bound(maxExposure, amount + 1, type(uint112).max));
+
+        uint256 exposureLimit = maxExposure_ - amount - 1;
+        uint256 usdLimit = maxAmount - amount - 1;
+        initialExposure_ = uint112(bound(initialExposure, 0, exposureLimit < usdLimit ? exposureLimit : usdLimit));
     }
 }

--- a/test/utils/fixtures/slipstream/Slipstream.f.sol
+++ b/test/utils/fixtures/slipstream/Slipstream.f.sol
@@ -5,6 +5,7 @@
 pragma solidity ^0.8.0;
 
 import { AerodromeFixture } from "../aerodrome/AerodromeFixture.f.sol";
+import { ConcentratedLiquidityFixture } from "../concentrated-liquidity/ConcentratedLiquidityFixture.f.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { FixedPoint128 } from "../../../../src/asset-modules/UniswapV3/libraries/FixedPoint128.sol";
 import { FullMath } from "../../../../src/asset-modules/UniswapV3/libraries/FullMath.sol";
@@ -20,14 +21,7 @@ import { Utils } from "../../Utils.sol";
 import { WETH9Fixture } from "../weth9/WETH9Fixture.f.sol";
 
 // forge-lint: disable-next-item(divide-before-multiply,encode-packed-collision,mixed-case-function,unsafe-typecast)
-contract SlipstreamFixture is WETH9Fixture, AerodromeFixture {
-    /*//////////////////////////////////////////////////////////////////////////
-                                   CONSTANTS
-    //////////////////////////////////////////////////////////////////////////*/
-
-    // The maximum priceToken0 / priceToken1 ratio for which sqrtPriceX96 stays below TickMath.MAX_SQRT_RATIO.
-    uint256 internal constant MAX_PRICE_RATIO = (uint256(TickMath.MAX_SQRT_RATIO) * 1e14 / 2 ** 96) ** 2 / 1e28;
-
+contract SlipstreamFixture is ConcentratedLiquidityFixture, WETH9Fixture, AerodromeFixture {
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -303,43 +297,5 @@ contract SlipstreamFixture is WETH9Fixture, AerodromeFixture {
                 feeGrowthInside1X128 = upperFeeGrowthOutside1X128 - lowerFeeGrowthOutside1X128;
             }
         }
-    }
-
-    function givenValidPrices(uint256 priceToken0, uint256 priceToken1)
-        public
-        pure
-        returns (uint256 priceToken0_, uint256 priceToken1_)
-    {
-        // Avoid divide by 0, which is already checked in earlier in function.
-        priceToken1_ = bound(priceToken1, 1, type(uint256).max / 10 ** 18);
-        // Function will overFlow, not realistic.
-        uint256 maxPriceToken0 = type(uint256).max / 10 ** 28;
-        // Cast to uint160 will overflow, not realistic.
-        if (priceToken1_ < 2 ** 128) {
-            uint256 maxRatio = priceToken1_ * MAX_PRICE_RATIO;
-            if (maxRatio < maxPriceToken0) maxPriceToken0 = maxRatio;
-        }
-        // A priceXd28 of 0 puts sqrtPriceX96 below the minimum.
-        priceToken0_ = bound(priceToken0, (priceToken1_ - 1) / 10 ** 28 + 1, maxPriceToken0);
-    }
-
-    function givenValidExposures(
-        uint256 amount,
-        uint112 initialExposure,
-        uint112 maxExposure,
-        uint256 price,
-        uint256 maxUsdValue
-    ) public pure returns (uint112 initialExposure_, uint112 maxExposure_) {
-        // Usd value of the underlying asset does not overflow.
-        uint256 maxAmount = maxUsdValue / price / 10 ** 18;
-        vm.assume(amount < type(uint112).max);
-        vm.assume(amount < maxAmount);
-
-        // Exposure to the underlying asset stays below maxExposure.
-        maxExposure_ = uint112(bound(maxExposure, amount + 1, type(uint112).max));
-
-        uint256 exposureLimit = maxExposure_ - amount - 1;
-        uint256 usdLimit = maxAmount - amount - 1;
-        initialExposure_ = uint112(bound(initialExposure, 0, exposureLimit < usdLimit ? exposureLimit : usdLimit));
     }
 }

--- a/test/utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol
@@ -17,7 +17,15 @@ import { TickMath } from "../../../../src/asset-modules/UniswapV3/libraries/Tick
 import { Utils } from "../../../utils/Utils.sol";
 import { WETH9Fixture } from "../weth9/WETH9Fixture.f.sol";
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract UniswapV3Fixture is WETH9Fixture {
+    /*//////////////////////////////////////////////////////////////////////////
+                                   CONSTANTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    // The maximum priceToken0 / priceToken1 ratio for which sqrtPriceX96 stays below TickMath.MAX_SQRT_RATIO.
+    uint256 internal constant MAX_PRICE_RATIO = (uint256(TickMath.MAX_SQRT_RATIO) * 1e14 / 2 ** 96) ** 2 / 1e28;
+
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -183,6 +191,53 @@ contract UniswapV3Fixture is WETH9Fixture {
                 deadline: type(uint256).max
             })
         );
+    }
+
+    function givenValidPrices(uint256 priceToken0, uint256 priceToken1)
+        public
+        pure
+        returns (uint256 priceToken0_, uint256 priceToken1_)
+    {
+        // Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1_ = bound(priceToken1, 1, type(uint256).max / 10 ** 18);
+        // Function will overFlow, not realistic.
+        uint256 maxPriceToken0 = type(uint256).max / 10 ** 28;
+        // Cast to uint160 will overflow, not realistic.
+        if (priceToken1_ < 2 ** 128) {
+            uint256 maxRatio = priceToken1_ * MAX_PRICE_RATIO;
+            if (maxRatio < maxPriceToken0) maxPriceToken0 = maxRatio;
+        }
+        // A priceXd28 of 0 puts sqrtPriceX96 below the minimum.
+        priceToken0_ = bound(priceToken0, (priceToken1_ - 1) / 10 ** 28 + 1, maxPriceToken0);
+    }
+
+    function givenValidExposures(
+        uint256 amount,
+        uint112 initialExposure,
+        uint112 maxExposure,
+        uint256 price,
+        uint256 maxUsdValue
+    ) public pure returns (uint112 initialExposure_, uint112 maxExposure_) {
+        // Usd value of the underlying asset does not overflow.
+        uint256 maxAmount = maxUsdValue / price / 10 ** 18;
+        vm.assume(amount < type(uint112).max);
+        vm.assume(amount < maxAmount);
+
+        // Exposure to the underlying asset stays below maxExposure.
+        maxExposure_ = uint112(bound(maxExposure, amount + 1, type(uint112).max));
+
+        uint256 exposureLimit = maxExposure_ - amount - 1;
+        uint256 usdLimit = maxAmount - amount - 1;
+        initialExposure_ = uint112(bound(initialExposure, 0, exposureLimit < usdLimit ? exposureLimit : usdLimit));
+    }
+
+    function givenValidTicks(int24 tickLower, int24 tickUpper)
+        public
+        pure
+        returns (int24 tickLower_, int24 tickUpper_)
+    {
+        tickLower_ = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
+        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, TickMath.MAX_TICK));
     }
 
     function isWithinAllowedRange(int24 tick) internal pure returns (bool) {

--- a/test/utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v3/UniswapV3Fixture.f.sol
@@ -4,6 +4,7 @@
  */
 pragma solidity ^0.8.0;
 
+import { ConcentratedLiquidityFixture } from "../concentrated-liquidity/ConcentratedLiquidityFixture.f.sol";
 import { Constants } from "../../../utils/Constants.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { FixedPoint128 } from "../../../../src/asset-modules/UniswapV3/libraries/FixedPoint128.sol";
@@ -18,14 +19,7 @@ import { Utils } from "../../../utils/Utils.sol";
 import { WETH9Fixture } from "../weth9/WETH9Fixture.f.sol";
 
 // forge-lint: disable-next-item(unsafe-typecast)
-contract UniswapV3Fixture is WETH9Fixture {
-    /*//////////////////////////////////////////////////////////////////////////
-                                   CONSTANTS
-    //////////////////////////////////////////////////////////////////////////*/
-
-    // The maximum priceToken0 / priceToken1 ratio for which sqrtPriceX96 stays below TickMath.MAX_SQRT_RATIO.
-    uint256 internal constant MAX_PRICE_RATIO = (uint256(TickMath.MAX_SQRT_RATIO) * 1e14 / 2 ** 96) ** 2 / 1e28;
-
+contract UniswapV3Fixture is ConcentratedLiquidityFixture, WETH9Fixture {
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS
     //////////////////////////////////////////////////////////////////////////*/
@@ -191,58 +185,6 @@ contract UniswapV3Fixture is WETH9Fixture {
                 deadline: type(uint256).max
             })
         );
-    }
-
-    function givenValidPrices(uint256 priceToken0, uint256 priceToken1)
-        public
-        pure
-        returns (uint256 priceToken0_, uint256 priceToken1_)
-    {
-        // Avoid divide by 0, which is already checked in earlier in function.
-        priceToken1_ = bound(priceToken1, 1, type(uint256).max / 10 ** 18);
-        // Function will overFlow, not realistic.
-        uint256 maxPriceToken0 = type(uint256).max / 10 ** 28;
-        // Cast to uint160 will overflow, not realistic.
-        if (priceToken1_ < 2 ** 128) {
-            uint256 maxRatio = priceToken1_ * MAX_PRICE_RATIO;
-            if (maxRatio < maxPriceToken0) maxPriceToken0 = maxRatio;
-        }
-        // A priceXd28 of 0 puts sqrtPriceX96 below the minimum.
-        priceToken0_ = bound(priceToken0, (priceToken1_ - 1) / 10 ** 28 + 1, maxPriceToken0);
-    }
-
-    function givenValidExposures(
-        uint256 amount,
-        uint112 initialExposure,
-        uint112 maxExposure,
-        uint256 price,
-        uint256 maxUsdValue
-    ) public pure returns (uint112 initialExposure_, uint112 maxExposure_) {
-        // Usd value of the underlying asset does not overflow.
-        uint256 maxAmount = maxUsdValue / price / 10 ** 18;
-        vm.assume(amount < type(uint112).max);
-        vm.assume(amount < maxAmount);
-
-        // Exposure to the underlying asset stays below maxExposure.
-        maxExposure_ = uint112(bound(maxExposure, amount + 1, type(uint112).max));
-
-        uint256 exposureLimit = maxExposure_ - amount - 1;
-        uint256 usdLimit = maxAmount - amount - 1;
-        initialExposure_ = uint112(bound(initialExposure, 0, exposureLimit < usdLimit ? exposureLimit : usdLimit));
-    }
-
-    function givenValidTicks(int24 tickLower, int24 tickUpper)
-        public
-        pure
-        returns (int24 tickLower_, int24 tickUpper_)
-    {
-        tickLower_ = int24(bound(tickLower, TickMath.MIN_TICK, TickMath.MAX_TICK - 2));
-        tickUpper_ = int24(bound(tickUpper, tickLower_ + 1, TickMath.MAX_TICK));
-    }
-
-    function isWithinAllowedRange(int24 tick) internal pure returns (bool) {
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return (tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick))) <= uint256(uint24(TickMath.MAX_TICK));
     }
 
     function getAmountsV3(uint256 id) internal view returns (uint256 amount0, uint256 amount1) {

--- a/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
@@ -23,6 +23,7 @@ import { LiquidityAmounts } from "../../../../src/asset-modules/UniswapV3/librar
 import { Permit2Fixture } from "../../../utils/fixtures/permit2/Permit2Fixture.f.sol";
 import { PoolKey } from "../../../../lib/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
 import { PositionInfoLibrary, PositionInfo } from "../../../../lib/v4-periphery/src/libraries/PositionInfoLibrary.sol";
+import { SqrtPriceMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/SqrtPriceMath.sol";
 import { StateLibrary } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/StateLibrary.sol";
 import { StateView } from "../../../../lib/v4-periphery/src/lens/StateView.sol";
 import { Test } from "../../../../lib/forge-std/src/Test.sol";
@@ -257,24 +258,15 @@ contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
 
         tokenId = positionManagerV4.nextTokenId();
 
-        (uint160 sqrtPriceX96,,,) = stateView.getSlot0(poolKey.toId());
-
-        (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
-            sqrtPriceX96,
-            TickMath.getSqrtPriceAtTick(tickLower),
-            TickMath.getSqrtPriceAtTick(tickUpper),
-            // forge-lint: disable-next-line(unsafe-typecast)
-            uint128(liquidity)
-        );
+        // forge-lint: disable-next-line(unsafe-typecast)
+        (uint256 amount0, uint256 amount1) = amountsOwedForLiquidity(poolKey, tickLower, tickUpper, uint128(liquidity));
 
         // Deal and approve tokens
         address token0 = Currency.unwrap(poolKey.currency0);
         address token1 = Currency.unwrap(poolKey.currency1);
 
-        // We can have some rounding issues between lib calculated amounts and contract, thus increase amount by 1
-        // Todo : further investigate rounding diff
-        token0 == address(0) ? vm.deal(liquidityProvider, amount0 + 1) : deal(token0, liquidityProvider, amount0 + 1);
-        deal(token1, liquidityProvider, amount1 + 1);
+        token0 == address(0) ? vm.deal(liquidityProvider, amount0) : deal(token0, liquidityProvider, amount0);
+        deal(token1, liquidityProvider, amount1);
 
         // Approvals via permit2
         if (token0 != address(0)) approveV4PositionManagerFor(liquidityProvider, token0);
@@ -282,7 +274,26 @@ contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
 
         vm.prank(liquidityProvider);
         // forge-lint: disable-next-item(arbitrary-send-eth)
-        positionManagerV4.modifyLiquidities{ value: token0 == address(0) ? amount0 + 1 : 0 }(mintData, block.timestamp);
+        positionManagerV4.modifyLiquidities{ value: token0 == address(0) ? amount0 : 0 }(mintData, block.timestamp);
+    }
+
+    function amountsOwedForLiquidity(PoolKey memory poolKey, int24 tickLower, int24 tickUpper, uint128 liquidity)
+        internal
+        view
+        returns (uint256 amount0, uint256 amount1)
+    {
+        (uint160 sqrtPriceX96, int24 tick,,) = stateView.getSlot0(poolKey.toId());
+        uint160 sqrtPriceLower = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtPriceUpper = TickMath.getSqrtPriceAtTick(tickUpper);
+
+        if (tick < tickLower) {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtPriceLower, sqrtPriceUpper, liquidity, true);
+        } else if (tick < tickUpper) {
+            amount0 = SqrtPriceMath.getAmount0Delta(sqrtPriceX96, sqrtPriceUpper, liquidity, true);
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtPriceLower, sqrtPriceX96, liquidity, true);
+        } else {
+            amount1 = SqrtPriceMath.getAmount1Delta(sqrtPriceLower, sqrtPriceUpper, liquidity, true);
+        }
     }
 
     function isWithinAllowedRangeV4(int24 tick) internal pure returns (bool) {

--- a/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
@@ -30,6 +30,7 @@ import { Test } from "../../../../lib/forge-std/src/Test.sol";
 import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
 import { WETH9Fixture } from "../weth9/WETH9Fixture.f.sol";
 
+// forge-lint: disable-next-item(unsafe-typecast)
 contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
     using PositionInfoLibrary for PositionInfo;
     using StateLibrary for IPoolManagerExtension;
@@ -48,15 +49,8 @@ contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
                                    CONSTANTS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// The minimum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**-128
-    int24 internal constant MIN_TICK = -887_272;
-    /// The maximum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**128
-    int24 internal constant MAX_TICK = 887_272;
-
-    /// The minimum value that can be returned from #getSqrtPriceAtTick. Equivalent to getSqrtPriceAtTick(MIN_TICK)
-    uint160 internal constant MIN_SQRT_PRICE = 4_295_128_739;
-    /// The maximum value that can be returned from #getSqrtPriceAtTick. Equivalent to getSqrtPriceAtTick(MAX_TICK)
-    uint160 internal constant MAX_SQRT_PRICE = 1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342;
+    // The maximum priceToken0 / priceToken1 ratio for which sqrtPriceX96 stays below TickMath.MAX_SQRT_PRICE.
+    uint256 internal constant MAX_PRICE_RATIO = (uint256(TickMath.MAX_SQRT_PRICE) * 1e14 / 2 ** 96) ** 2 / 1e28;
 
     // A struct with the data to encode for position manager actions
     struct Plan {
@@ -296,9 +290,47 @@ contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
         }
     }
 
+    function givenValidPrices(uint256 priceToken0, uint256 priceToken1)
+        public
+        pure
+        returns (uint256 priceToken0_, uint256 priceToken1_)
+    {
+        // Avoid divide by 0, which is already checked in earlier in function.
+        priceToken1_ = bound(priceToken1, 1, type(uint256).max / 10 ** 18);
+        // Function will overFlow, not realistic.
+        uint256 maxPriceToken0 = type(uint256).max / 10 ** 28;
+        // Cast to uint160 will overflow, not realistic.
+        if (priceToken1_ < 2 ** 128) {
+            uint256 maxRatio = priceToken1_ * MAX_PRICE_RATIO;
+            if (maxRatio < maxPriceToken0) maxPriceToken0 = maxRatio;
+        }
+        // A priceXd28 of 0 puts sqrtPriceX96 below the minimum.
+        priceToken0_ = bound(priceToken0, (priceToken1_ - 1) / 10 ** 28 + 1, maxPriceToken0);
+    }
+
+    function givenValidExposures(
+        uint256 amount,
+        uint112 initialExposure,
+        uint112 maxExposure,
+        uint256 price,
+        uint256 maxUsdValue
+    ) public pure returns (uint112 initialExposure_, uint112 maxExposure_) {
+        // Usd value of the underlying asset does not overflow.
+        uint256 maxAmount = maxUsdValue / price / 10 ** 18;
+        vm.assume(amount < type(uint112).max);
+        vm.assume(amount < maxAmount);
+
+        // Exposure to the underlying asset stays below maxExposure.
+        maxExposure_ = uint112(bound(maxExposure, amount + 1, type(uint112).max));
+
+        uint256 exposureLimit = maxExposure_ - amount - 1;
+        uint256 usdLimit = maxAmount - amount - 1;
+        initialExposure_ = uint112(bound(initialExposure, 0, exposureLimit < usdLimit ? exposureLimit : usdLimit));
+    }
+
     function isWithinAllowedRangeV4(int24 tick) internal pure returns (bool) {
         // forge-lint: disable-next-line(unsafe-typecast)
-        return (tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick))) <= uint256(uint24(MAX_TICK));
+        return (tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick))) <= uint256(uint24(TickMath.MAX_TICK));
     }
 
     function getAmountsV4(uint256 id) internal view returns (uint256 amount0, uint256 amount1) {

--- a/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
+++ b/test/utils/fixtures/uniswap-v4/UniswapV4Fixture.f.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { Actions } from "../../../../lib/v4-periphery/src/libraries/Actions.sol";
 import { ActionConstants } from "../../../../lib/v4-periphery/src/libraries/ActionConstants.sol";
 import { BaseHookExtension } from "./extensions/BaseHookExtension.sol";
+import { ConcentratedLiquidityFixture } from "../concentrated-liquidity/ConcentratedLiquidityFixture.f.sol";
 import { Currency } from "../../../../lib/v4-periphery/lib/v4-core/src/types/Currency.sol";
 import { ERC20 } from "../../../../lib/solmate/src/tokens/ERC20.sol";
 import { FixedPoint128 } from "../../../../src/asset-modules/UniswapV3/libraries/FixedPoint128.sol";
@@ -31,7 +32,7 @@ import { TickMath } from "../../../../lib/v4-periphery/lib/v4-core/src/libraries
 import { WETH9Fixture } from "../weth9/WETH9Fixture.f.sol";
 
 // forge-lint: disable-next-item(unsafe-typecast)
-contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
+contract UniswapV4Fixture is Test, ConcentratedLiquidityFixture, Permit2Fixture, WETH9Fixture {
     using PositionInfoLibrary for PositionInfo;
     using StateLibrary for IPoolManagerExtension;
     /*//////////////////////////////////////////////////////////////////////////
@@ -48,9 +49,6 @@ contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
     /*//////////////////////////////////////////////////////////////////////////
                                    CONSTANTS
     //////////////////////////////////////////////////////////////////////////*/
-
-    // The maximum priceToken0 / priceToken1 ratio for which sqrtPriceX96 stays below TickMath.MAX_SQRT_PRICE.
-    uint256 internal constant MAX_PRICE_RATIO = (uint256(TickMath.MAX_SQRT_PRICE) * 1e14 / 2 ** 96) ** 2 / 1e28;
 
     // A struct with the data to encode for position manager actions
     struct Plan {
@@ -288,49 +286,6 @@ contract UniswapV4Fixture is Test, Permit2Fixture, WETH9Fixture {
         } else {
             amount1 = SqrtPriceMath.getAmount1Delta(sqrtPriceLower, sqrtPriceUpper, liquidity, true);
         }
-    }
-
-    function givenValidPrices(uint256 priceToken0, uint256 priceToken1)
-        public
-        pure
-        returns (uint256 priceToken0_, uint256 priceToken1_)
-    {
-        // Avoid divide by 0, which is already checked in earlier in function.
-        priceToken1_ = bound(priceToken1, 1, type(uint256).max / 10 ** 18);
-        // Function will overFlow, not realistic.
-        uint256 maxPriceToken0 = type(uint256).max / 10 ** 28;
-        // Cast to uint160 will overflow, not realistic.
-        if (priceToken1_ < 2 ** 128) {
-            uint256 maxRatio = priceToken1_ * MAX_PRICE_RATIO;
-            if (maxRatio < maxPriceToken0) maxPriceToken0 = maxRatio;
-        }
-        // A priceXd28 of 0 puts sqrtPriceX96 below the minimum.
-        priceToken0_ = bound(priceToken0, (priceToken1_ - 1) / 10 ** 28 + 1, maxPriceToken0);
-    }
-
-    function givenValidExposures(
-        uint256 amount,
-        uint112 initialExposure,
-        uint112 maxExposure,
-        uint256 price,
-        uint256 maxUsdValue
-    ) public pure returns (uint112 initialExposure_, uint112 maxExposure_) {
-        // Usd value of the underlying asset does not overflow.
-        uint256 maxAmount = maxUsdValue / price / 10 ** 18;
-        vm.assume(amount < type(uint112).max);
-        vm.assume(amount < maxAmount);
-
-        // Exposure to the underlying asset stays below maxExposure.
-        maxExposure_ = uint112(bound(maxExposure, amount + 1, type(uint112).max));
-
-        uint256 exposureLimit = maxExposure_ - amount - 1;
-        uint256 usdLimit = maxAmount - amount - 1;
-        initialExposure_ = uint112(bound(initialExposure, 0, exposureLimit < usdLimit ? exposureLimit : usdLimit));
-    }
-
-    function isWithinAllowedRangeV4(int24 tick) internal pure returns (bool) {
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return (tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick))) <= uint256(uint24(TickMath.MAX_TICK));
     }
 
     function getAmountsV4(uint256 id) internal view returns (uint256 amount0, uint256 amount1) {

--- a/test/utils/mocks/Aerodrome/AeroPoolFactoryMock.sol
+++ b/test/utils/mocks/Aerodrome/AeroPoolFactoryMock.sol
@@ -9,9 +9,12 @@ import { Clones } from "../../../../lib/openzeppelin-contracts-v4.9/contracts/pr
 
 // forge-lint: disable-next-item(screaming-snake-case-immutable)
 contract PoolFactory {
+    // forge-lint: disable-next-item(event-fields)
     event SetFeeManager(address feeManager);
+    // forge-lint: disable-next-item(event-fields)
     event SetPauser(address pauser);
     event SetPauseState(bool state);
+    // forge-lint: disable-next-item(event-fields)
     event SetVoter(address voter);
     event PoolCreated(address indexed token0, address indexed token1, bool indexed stable, address pool, uint256);
     event SetCustomFee(address indexed pool, uint256 fee);

--- a/test/utils/mocks/accounts/AccountLogicMock.sol
+++ b/test/utils/mocks/accounts/AccountLogicMock.sol
@@ -98,6 +98,7 @@ contract AccountLogicMock is AccountStorageV2 {
     /**
      * @dev Throws if called by any account other than an Asset Manager or the owner.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyAssetManager() {
         // A custom error would need to read out owner + creditor + isAssetManager storage
         require(

--- a/test/utils/mocks/asset-modules/PrimaryAMMock.sol
+++ b/test/utils/mocks/asset-modules/PrimaryAMMock.sol
@@ -4,52 +4,11 @@ pragma solidity ^0.8.0;
 import { PrimaryAMExtension } from "../../extensions/PrimaryAMExtension.sol";
 
 contract PrimaryAMMock is PrimaryAMExtension {
-    // Price is 1 by default
-    bool useRealUsdValue;
-    uint256 usdExposureToUnderlyingAsset = 1;
-
     constructor(address owner_, address registry_, uint256 assetType_)
         PrimaryAMExtension(owner_, registry_, assetType_)
     { }
 
     function isAllowed(address asset, uint256) public view override returns (bool) {
         return inAssetModule[asset];
-    }
-
-    function setAssetInformation(address asset, uint256 assetId, uint64 assetUnit, bytes32 oracles) public {
-        bytes32 assetKey = _getKeyFromAsset(asset, assetId);
-        assetToInformation[assetKey].assetUnit = assetUnit;
-        assetToInformation[assetKey].oracleSequence = oracles;
-    }
-
-    // ToDo: Refactor, due to legacy tests with getValue hardcoded we now use a workaround
-    // with the state variable useRealUsdValue to see if we use the hardcoded or actual getValue function.
-    function setUseRealUsdValue(bool status) public {
-        useRealUsdValue = status;
-    }
-
-    function setUsdValue(uint256 usdExposureToUnderlyingAsset_) public {
-        usdExposureToUnderlyingAsset = usdExposureToUnderlyingAsset_;
-    }
-
-    // The function below is only needed in the case of testing for the "AbstractDerivedAM", in order for the Primary Asset to return a value
-    // getValue() will be tested separately per PM.
-    function getValue(address creditor, address asset, uint256 assetId, uint256 amount)
-        public
-        view
-        override
-        returns (uint256 valueInUsd, uint256 collateralFactor, uint256 liquidationFactor)
-    {
-        // ToDo: Refactor, due to legacy tests with getValue hardcoded we now use a workaround
-        // with the state variable useRealUsdValue to see if we use the hardcoded or actual getValue function.
-        if (useRealUsdValue) {
-            (valueInUsd, collateralFactor, liquidationFactor) = super.getValue(creditor, asset, assetId, amount);
-        } else {
-            // we assume a price of 1 for this testing purpose
-            valueInUsd = usdExposureToUnderlyingAsset;
-            bytes32 assetKey = _getKeyFromAsset(asset, assetId);
-            collateralFactor = riskParams[creditor][assetKey].collateralFactor;
-            liquidationFactor = riskParams[creditor][assetKey].liquidationFactor;
-        }
     }
 }

--- a/test/utils/mocks/merkl/OperatorMock.sol
+++ b/test/utils/mocks/merkl/OperatorMock.sol
@@ -7,5 +7,6 @@ pragma solidity ^0.8.0;
 import { IMerklOperator } from "../../../../src/interfaces/IMerklOperator.sol";
 
 contract OperatorMock is IMerklOperator {
+    // forge-lint: disable-next-item(empty-block)
     function onSetMerklOperator(address accountOwner, bool status, bytes calldata data) external { }
 }

--- a/test/utils/mocks/oracles/ArcadiaOracle.sol
+++ b/test/utils/mocks/oracles/ArcadiaOracle.sol
@@ -65,6 +65,7 @@ contract ArcadiaOracle is Owned {
     /**
      * @dev Throws if called by any account other than the transmitter.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyTransmitter() {
         require(offchainConnectors[msg.sender].role == Role.Transmitter, "Oracle: caller is not the valid transmitter");
         require(offchainConnectors[msg.sender].isActive, "Oracle: transmitter is not active");

--- a/test/utils/mocks/tokens/ERC721Mock.sol
+++ b/test/utils/mocks/tokens/ERC721Mock.sol
@@ -11,6 +11,7 @@ contract ERC721Mock is ERC721 {
     string baseURI;
     address owner;
 
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyOwner() {
         require(msg.sender == owner, "You are not the owner");
         _;


### PR DESCRIPTION
Replaces `vm.assume` with `bound` wherever the constrained value is a fuzz input, so runs are steered into the valid domain instead of being discarded.

- Derives the exact `priceToken0 / priceToken1` band in `givenValidPrices`. The previous `2 ** 128` cap allowed `sqrtPriceX96 == 2 ** 160`, one step above `MAX_SQRT_RATIO`, which is what the `sqrtPriceX96` guards in `calculateAndValidateRangeTickCurrent` were absorbing. Those guards are now unreachable and removed.
- Caps liquidity through `getLiquidityForAmounts` in `GetUnderlyingAssetsAmounts`, so the derived `amount0` / `amount1` stay within `uint96` and the principal limits.
- Bounds `amountToken1` in the registry collateral/liquidation tests instead of asserting the USD value is non-zero.
- Reuses v4-core's `TickMath` constants instead of re-declaring `MIN_TICK`, `MAX_TICK`, `MIN_SQRT_PRICE` and `MAX_SQRT_PRICE`, and drops the raw sqrt-ratio literals from the `GetValue` tests.
- Removes re-bounds whose range was a superset of the preceding bound, one of which sat between a value and an assertion derived from it.

The remaining assumes are address holes, state predicates, dynamic lengths, and values derived from the function under test.

`forge test`, `forge lint` and `forge fmt --check` are clean.
